### PR TITLE
Add tests for document ids with special characters

### DIFF
--- a/src/CloudantClient.PCL/src/Database.cs
+++ b/src/CloudantClient.PCL/src/Database.cs
@@ -187,7 +187,7 @@ namespace IBM.Cloudant.Client
                     "parameter must not be null or empty");
                 }
 
-                Uri requestUrl = new Uri (dbNameUrlEncoded + "/" + documentId, UriKind.Relative);
+                Uri requestUrl = new Uri (dbNameUrlEncoded + "/" + Uri.EscapeDataString (documentId), UriKind.Relative);
                 Debug.WriteLine ("fetch document relative URI is: " + requestUrl.ToString ());
 
                 Task<DocumentRevision> result = Task.Run (() => {
@@ -266,7 +266,7 @@ namespace IBM.Cloudant.Client
                 }
 
                 Uri requestUrl = new Uri (dbNameUrlEncoded + "/"
-                                 + revision.docId + "?rev=" + revision.revId, UriKind.Relative);
+                                 + Uri.EscapeDataString (revision.docId) + "?rev=" + Uri.EscapeDataString (revision.revId), UriKind.Relative);
                 Task<String> result = Task.Run (() => {
                     // Send the HTTP request
                     Task<HttpResponseMessage> httpTask = client.httpHelper.sendDelete (requestUrl, null);
@@ -595,7 +595,11 @@ namespace IBM.Cloudant.Client
             Debug.WriteLine ("=== enter Database::createDocumentRevision()");
             try {
                 Uri uri = null;
-                uri = new Uri (dbNameUrlEncoded + "/" + doc.docId, UriKind.Relative);
+                string encodedDocId = null;
+                if (doc.docId != null) {
+                    encodedDocId = Uri.EscapeDataString (doc.docId);
+                }
+                uri = new Uri (dbNameUrlEncoded + "/" + encodedDocId, UriKind.Relative);
                 Debug.WriteLine ("reltive URL is: " + uri.ToString ());
 
                 Dictionary<String,Object> payload = ConvertDocToJSONPayload (doc);
@@ -683,7 +687,7 @@ namespace IBM.Cloudant.Client
 
 
                 if (doc.docId != null) {
-                    uri = new Uri (dbNameUrlEncoded + "/" + doc.docId, UriKind.Relative);
+                    uri = new Uri (dbNameUrlEncoded + "/" + Uri.EscapeDataString (doc.docId), UriKind.Relative);
                 } else {
                     string errorMessage = "HTTP request to update document failed: the document revision must contain docId";
                     throw new DataException (DataException.Database_SaveDocumentRevisionFailure, errorMessage);

--- a/src/CloudantClient.PCL/src/DocumentRevision.cs
+++ b/src/CloudantClient.PCL/src/DocumentRevision.cs
@@ -12,7 +12,8 @@
 //  and limitations under the License.
 using System;
 using System.Collections.Generic;
-
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 
 namespace IBM.Cloudant.Client
 {
@@ -22,7 +23,7 @@ namespace IBM.Cloudant.Client
     /// <remarks>
     /// This class contains the metadata and content associated with a Cloudant document revision.
     /// </remarks>
-    public class DocumentRevision
+    public class DocumentRevision : IEquatable<DocumentRevision>
     {
         private static string DOC_ID = "_id";
         private static string DOC_REV = "_rev";
@@ -88,6 +89,22 @@ namespace IBM.Cloudant.Client
                 isDeleted = (Boolean)deleted;
                 body.Remove (DOC_DELETED);
             }
+        }
+
+        public bool Equals (DocumentRevision other)
+        {
+
+            var otherBody = JToken.FromObject (other.body);
+            var thisBody = JToken.FromObject (this.body);
+
+            return this.docId.Equals (other.docId) && this.revId.Equals (other.revId) && JToken.DeepEquals (thisBody, otherBody);
+        }
+
+        override public string ToString ()
+        {
+
+            string body = JsonConvert.SerializeObject (this.body);
+            return "{ id:" + this.docId + ", revId:" + this.revId + ", " + body + " }";
         }
     }
 }

--- a/src/Test.Android/Resources/Resource.designer.cs
+++ b/src/Test.Android/Resources/Resource.designer.cs
@@ -13,163 +13,163 @@
 
 namespace Test.Android
 {
-    
-    
-    [System.CodeDom.Compiler.GeneratedCodeAttribute("Xamarin.Android.Build.Tasks", "1.0.0.0")]
-    public partial class Resource
-    {
-        
-        static Resource()
-        {
-            global::Android.Runtime.ResourceIdManager.UpdateIdValues();
-        }
-        
-        public static void UpdateIdValues()
-        {
-            global::Xamarin.Android.NUnitLite.Resource.Id.OptionHostName = global::Test.Android.Resource.Id.OptionHostName;
-            global::Xamarin.Android.NUnitLite.Resource.Id.OptionPort = global::Test.Android.Resource.Id.OptionPort;
-            global::Xamarin.Android.NUnitLite.Resource.Id.OptionRemoteServer = global::Test.Android.Resource.Id.OptionRemoteServer;
-            global::Xamarin.Android.NUnitLite.Resource.Id.OptionsButton = global::Test.Android.Resource.Id.OptionsButton;
-            global::Xamarin.Android.NUnitLite.Resource.Id.ResultFullName = global::Test.Android.Resource.Id.ResultFullName;
-            global::Xamarin.Android.NUnitLite.Resource.Id.ResultMessage = global::Test.Android.Resource.Id.ResultMessage;
-            global::Xamarin.Android.NUnitLite.Resource.Id.ResultResultState = global::Test.Android.Resource.Id.ResultResultState;
-            global::Xamarin.Android.NUnitLite.Resource.Id.ResultRunSingleMethodTest = global::Test.Android.Resource.Id.ResultRunSingleMethodTest;
-            global::Xamarin.Android.NUnitLite.Resource.Id.ResultStackTrace = global::Test.Android.Resource.Id.ResultStackTrace;
-            global::Xamarin.Android.NUnitLite.Resource.Id.ResultsFailed = global::Test.Android.Resource.Id.ResultsFailed;
-            global::Xamarin.Android.NUnitLite.Resource.Id.ResultsId = global::Test.Android.Resource.Id.ResultsId;
-            global::Xamarin.Android.NUnitLite.Resource.Id.ResultsIgnored = global::Test.Android.Resource.Id.ResultsIgnored;
-            global::Xamarin.Android.NUnitLite.Resource.Id.ResultsInconclusive = global::Test.Android.Resource.Id.ResultsInconclusive;
-            global::Xamarin.Android.NUnitLite.Resource.Id.ResultsMessage = global::Test.Android.Resource.Id.ResultsMessage;
-            global::Xamarin.Android.NUnitLite.Resource.Id.ResultsPassed = global::Test.Android.Resource.Id.ResultsPassed;
-            global::Xamarin.Android.NUnitLite.Resource.Id.ResultsResult = global::Test.Android.Resource.Id.ResultsResult;
-            global::Xamarin.Android.NUnitLite.Resource.Id.RunTestsButton = global::Test.Android.Resource.Id.RunTestsButton;
-            global::Xamarin.Android.NUnitLite.Resource.Id.TestSuiteListView = global::Test.Android.Resource.Id.TestSuiteListView;
-            global::Xamarin.Android.NUnitLite.Resource.Layout.options = global::Test.Android.Resource.Layout.options;
-            global::Xamarin.Android.NUnitLite.Resource.Layout.results = global::Test.Android.Resource.Layout.results;
-            global::Xamarin.Android.NUnitLite.Resource.Layout.test_result = global::Test.Android.Resource.Layout.test_result;
-            global::Xamarin.Android.NUnitLite.Resource.Layout.test_suite = global::Test.Android.Resource.Layout.test_suite;
-        }
-        
-        public partial class Attribute
-        {
-            
-            static Attribute()
-            {
-                global::Android.Runtime.ResourceIdManager.UpdateIdValues();
-            }
-            
-            private Attribute()
-            {
-            }
-        }
-        
-        public partial class Drawable
-        {
-            
-            // aapt resource value: 0x7f020000
-            public const int Icon = 2130837504;
-            
-            static Drawable()
-            {
-                global::Android.Runtime.ResourceIdManager.UpdateIdValues();
-            }
-            
-            private Drawable()
-            {
-            }
-        }
-        
-        public partial class Id
-        {
-            
-            // aapt resource value: 0x7f040001
-            public const int OptionHostName = 2130968577;
-            
-            // aapt resource value: 0x7f040002
-            public const int OptionPort = 2130968578;
-            
-            // aapt resource value: 0x7f040000
-            public const int OptionRemoteServer = 2130968576;
-            
-            // aapt resource value: 0x7f040010
-            public const int OptionsButton = 2130968592;
-            
-            // aapt resource value: 0x7f04000b
-            public const int ResultFullName = 2130968587;
-            
-            // aapt resource value: 0x7f04000d
-            public const int ResultMessage = 2130968589;
-            
-            // aapt resource value: 0x7f04000c
-            public const int ResultResultState = 2130968588;
-            
-            // aapt resource value: 0x7f04000a
-            public const int ResultRunSingleMethodTest = 2130968586;
-            
-            // aapt resource value: 0x7f04000e
-            public const int ResultStackTrace = 2130968590;
-            
-            // aapt resource value: 0x7f040006
-            public const int ResultsFailed = 2130968582;
-            
-            // aapt resource value: 0x7f040003
-            public const int ResultsId = 2130968579;
-            
-            // aapt resource value: 0x7f040007
-            public const int ResultsIgnored = 2130968583;
-            
-            // aapt resource value: 0x7f040008
-            public const int ResultsInconclusive = 2130968584;
-            
-            // aapt resource value: 0x7f040009
-            public const int ResultsMessage = 2130968585;
-            
-            // aapt resource value: 0x7f040005
-            public const int ResultsPassed = 2130968581;
-            
-            // aapt resource value: 0x7f040004
-            public const int ResultsResult = 2130968580;
-            
-            // aapt resource value: 0x7f04000f
-            public const int RunTestsButton = 2130968591;
-            
-            // aapt resource value: 0x7f040011
-            public const int TestSuiteListView = 2130968593;
-            
-            static Id()
-            {
-                global::Android.Runtime.ResourceIdManager.UpdateIdValues();
-            }
-            
-            private Id()
-            {
-            }
-        }
-        
-        public partial class Layout
-        {
-            
-            // aapt resource value: 0x7f030000
-            public const int options = 2130903040;
-            
-            // aapt resource value: 0x7f030001
-            public const int results = 2130903041;
-            
-            // aapt resource value: 0x7f030002
-            public const int test_result = 2130903042;
-            
-            // aapt resource value: 0x7f030003
-            public const int test_suite = 2130903043;
-            
-            static Layout()
-            {
-                global::Android.Runtime.ResourceIdManager.UpdateIdValues();
-            }
-            
-            private Layout()
-            {
-            }
-        }
-    }
+	
+	
+	[System.CodeDom.Compiler.GeneratedCodeAttribute("Xamarin.Android.Build.Tasks", "1.0.0.0")]
+	public partial class Resource
+	{
+		
+		static Resource()
+		{
+			global::Android.Runtime.ResourceIdManager.UpdateIdValues();
+		}
+		
+		public static void UpdateIdValues()
+		{
+			global::Xamarin.Android.NUnitLite.Resource.Id.OptionHostName = global::Test.Android.Resource.Id.OptionHostName;
+			global::Xamarin.Android.NUnitLite.Resource.Id.OptionPort = global::Test.Android.Resource.Id.OptionPort;
+			global::Xamarin.Android.NUnitLite.Resource.Id.OptionRemoteServer = global::Test.Android.Resource.Id.OptionRemoteServer;
+			global::Xamarin.Android.NUnitLite.Resource.Id.OptionsButton = global::Test.Android.Resource.Id.OptionsButton;
+			global::Xamarin.Android.NUnitLite.Resource.Id.ResultFullName = global::Test.Android.Resource.Id.ResultFullName;
+			global::Xamarin.Android.NUnitLite.Resource.Id.ResultMessage = global::Test.Android.Resource.Id.ResultMessage;
+			global::Xamarin.Android.NUnitLite.Resource.Id.ResultResultState = global::Test.Android.Resource.Id.ResultResultState;
+			global::Xamarin.Android.NUnitLite.Resource.Id.ResultRunSingleMethodTest = global::Test.Android.Resource.Id.ResultRunSingleMethodTest;
+			global::Xamarin.Android.NUnitLite.Resource.Id.ResultStackTrace = global::Test.Android.Resource.Id.ResultStackTrace;
+			global::Xamarin.Android.NUnitLite.Resource.Id.ResultsFailed = global::Test.Android.Resource.Id.ResultsFailed;
+			global::Xamarin.Android.NUnitLite.Resource.Id.ResultsId = global::Test.Android.Resource.Id.ResultsId;
+			global::Xamarin.Android.NUnitLite.Resource.Id.ResultsIgnored = global::Test.Android.Resource.Id.ResultsIgnored;
+			global::Xamarin.Android.NUnitLite.Resource.Id.ResultsInconclusive = global::Test.Android.Resource.Id.ResultsInconclusive;
+			global::Xamarin.Android.NUnitLite.Resource.Id.ResultsMessage = global::Test.Android.Resource.Id.ResultsMessage;
+			global::Xamarin.Android.NUnitLite.Resource.Id.ResultsPassed = global::Test.Android.Resource.Id.ResultsPassed;
+			global::Xamarin.Android.NUnitLite.Resource.Id.ResultsResult = global::Test.Android.Resource.Id.ResultsResult;
+			global::Xamarin.Android.NUnitLite.Resource.Id.RunTestsButton = global::Test.Android.Resource.Id.RunTestsButton;
+			global::Xamarin.Android.NUnitLite.Resource.Id.TestSuiteListView = global::Test.Android.Resource.Id.TestSuiteListView;
+			global::Xamarin.Android.NUnitLite.Resource.Layout.options = global::Test.Android.Resource.Layout.options;
+			global::Xamarin.Android.NUnitLite.Resource.Layout.results = global::Test.Android.Resource.Layout.results;
+			global::Xamarin.Android.NUnitLite.Resource.Layout.test_result = global::Test.Android.Resource.Layout.test_result;
+			global::Xamarin.Android.NUnitLite.Resource.Layout.test_suite = global::Test.Android.Resource.Layout.test_suite;
+		}
+		
+		public partial class Attribute
+		{
+			
+			static Attribute()
+			{
+				global::Android.Runtime.ResourceIdManager.UpdateIdValues();
+			}
+			
+			private Attribute()
+			{
+			}
+		}
+		
+		public partial class Drawable
+		{
+			
+			// aapt resource value: 0x7f020000
+			public const int Icon = 2130837504;
+			
+			static Drawable()
+			{
+				global::Android.Runtime.ResourceIdManager.UpdateIdValues();
+			}
+			
+			private Drawable()
+			{
+			}
+		}
+		
+		public partial class Id
+		{
+			
+			// aapt resource value: 0x7f040001
+			public const int OptionHostName = 2130968577;
+			
+			// aapt resource value: 0x7f040002
+			public const int OptionPort = 2130968578;
+			
+			// aapt resource value: 0x7f040000
+			public const int OptionRemoteServer = 2130968576;
+			
+			// aapt resource value: 0x7f040010
+			public const int OptionsButton = 2130968592;
+			
+			// aapt resource value: 0x7f04000b
+			public const int ResultFullName = 2130968587;
+			
+			// aapt resource value: 0x7f04000d
+			public const int ResultMessage = 2130968589;
+			
+			// aapt resource value: 0x7f04000c
+			public const int ResultResultState = 2130968588;
+			
+			// aapt resource value: 0x7f04000a
+			public const int ResultRunSingleMethodTest = 2130968586;
+			
+			// aapt resource value: 0x7f04000e
+			public const int ResultStackTrace = 2130968590;
+			
+			// aapt resource value: 0x7f040006
+			public const int ResultsFailed = 2130968582;
+			
+			// aapt resource value: 0x7f040003
+			public const int ResultsId = 2130968579;
+			
+			// aapt resource value: 0x7f040007
+			public const int ResultsIgnored = 2130968583;
+			
+			// aapt resource value: 0x7f040008
+			public const int ResultsInconclusive = 2130968584;
+			
+			// aapt resource value: 0x7f040009
+			public const int ResultsMessage = 2130968585;
+			
+			// aapt resource value: 0x7f040005
+			public const int ResultsPassed = 2130968581;
+			
+			// aapt resource value: 0x7f040004
+			public const int ResultsResult = 2130968580;
+			
+			// aapt resource value: 0x7f04000f
+			public const int RunTestsButton = 2130968591;
+			
+			// aapt resource value: 0x7f040011
+			public const int TestSuiteListView = 2130968593;
+			
+			static Id()
+			{
+				global::Android.Runtime.ResourceIdManager.UpdateIdValues();
+			}
+			
+			private Id()
+			{
+			}
+		}
+		
+		public partial class Layout
+		{
+			
+			// aapt resource value: 0x7f030000
+			public const int options = 2130903040;
+			
+			// aapt resource value: 0x7f030001
+			public const int results = 2130903041;
+			
+			// aapt resource value: 0x7f030002
+			public const int test_result = 2130903042;
+			
+			// aapt resource value: 0x7f030003
+			public const int test_suite = 2130903043;
+			
+			static Layout()
+			{
+				global::Android.Runtime.ResourceIdManager.UpdateIdValues();
+			}
+			
+			private Layout()
+			{
+			}
+		}
+	}
 }
 #pragma warning restore 1591

--- a/src/Test.Shared/DatabaseCRUDTests.cs
+++ b/src/Test.Shared/DatabaseCRUDTests.cs
@@ -357,7 +357,436 @@ namespace Test.Shared
 
         }
 
+        [Test]
+        public void testCreateDocumentWithSlash ()
+        {
+            var document = new DocumentRevision () {
+                docId = "my/document",
+                body = new Dictionary<string,Object> () {
+                    ["hello" ] = "world"
+                }
+            };
+
+            var savedDocument = CreateAndAssert (document);
+
+            //read
+            ReadAndAssert (document, savedDocument);
+
+            // update
+            var updated = UpdateAndAssert (document, savedDocument);
+
+            // delete
+            DeleteAndAssert (updated);
+
+        }
+
+        [Test]
+        public void testCreateDocumentInDbWithSlash ()
+        {
+            
+            var db = client.Database ("my/database");
+            try {
+                db.EnsureExists ();
+
+                var document = new DocumentRevision () {
+                    docId = "my/document",
+                    body = new Dictionary<string,Object> () {
+                    ["hello" ] = "world"
+                    }
+                };
+
+                var savedDocument = CreateAndAssert (document);
+
+                //read
+                ReadAndAssert (document, savedDocument);
+
+                // update
+                var updated = UpdateAndAssert (document, savedDocument);
+
+                // delete
+                DeleteAndAssert (updated);
+            } finally {
+                db.Delete ().Wait ();
+            }
+
+        }
+
+
+        [Test]
+        public void testCreateDocumentWithColon ()
+        {
+            var document = new DocumentRevision () {
+                docId = "my:document",
+                body = new Dictionary<string,Object> () {
+                    ["hello" ] = "world"
+                }
+            };
+
+            var savedDocument = CreateAndAssert (document);
+
+            //read
+            ReadAndAssert (document, savedDocument);
+
+            // update
+            var updated = UpdateAndAssert (document, savedDocument);
+
+            // delete
+            DeleteAndAssert (updated);
+        }
+
+        [Test]
+        public void testCreateDocumentWithQuestionMark ()
+        {
+            var document = new DocumentRevision () {
+                docId = "my?document",
+                body = new Dictionary<string,Object> () {
+                    ["hello" ] = "world"
+                }
+            };
+
+            var savedDocument = CreateAndAssert (document);
+
+            //read
+            ReadAndAssert (document, savedDocument);
+
+            // update
+            var updated = UpdateAndAssert (document, savedDocument);
+
+            // delete
+            DeleteAndAssert (updated);
+        }
+
+        [Test]
+        public void testCreateDocumentWithAt ()
+        {
+            var document = new DocumentRevision () {
+                docId = "my@document",
+                body = new Dictionary<string,Object> () {
+                    ["hello" ] = "world"
+                }
+            };
+
+            var savedDocument = CreateAndAssert (document);
+
+            //read
+            ReadAndAssert (document, savedDocument);
+
+            // update
+            var updated = UpdateAndAssert (document, savedDocument);
+
+            // delete
+            DeleteAndAssert (updated);
+        }
+
+        [Test]
+        public void testCreateDocumentWithHash ()
+        {
+            var document = new DocumentRevision () {
+                docId = "my#document",
+                body = new Dictionary<string,Object> () {
+                    ["hello" ] = "world"
+                }
+            };
+
+            var savedDocument = CreateAndAssert (document);
+
+            //read
+            ReadAndAssert (document, savedDocument);
+
+            // update
+            var updated = UpdateAndAssert (document, savedDocument);
+
+            // delete
+            DeleteAndAssert (updated);
+        }
+
+        [Test]
+        public void testCreateDocumentWithSquareBrackets ()
+        {
+            var document = new DocumentRevision () {
+                docId = "my[document]",
+                body = new Dictionary<string,Object> () {
+                    ["hello" ] = "world"
+                }
+            };
+
+            var savedDocument = CreateAndAssert (document);
+
+            //read
+            ReadAndAssert (document, savedDocument);
+
+            // update
+            var updated = UpdateAndAssert (document, savedDocument);
+
+            // delete
+            DeleteAndAssert (updated);
+        }
+
+        [Test]
+        public void testCreateDocumentWithDollar ()
+        {
+            var document = new DocumentRevision () {
+                docId = "my$document",
+                body = new Dictionary<string,Object> () {
+                    ["hello" ] = "world"
+                }
+            };
+
+            var savedDocument = CreateAndAssert (document);
+
+            //read
+            ReadAndAssert (document, savedDocument);
+
+            // update
+            var updated = UpdateAndAssert (document, savedDocument);
+
+            // delete
+            DeleteAndAssert (updated);
+        }
+
+        [Test]
+        public void testCreateDocumentWithApostrophe ()
+        {
+            var document = new DocumentRevision () {
+                docId = "my'document",
+                body = new Dictionary<string,Object> () {
+                    ["hello" ] = "world"
+                }
+            };
+
+            var savedDocument = CreateAndAssert (document);
+
+            //read
+            ReadAndAssert (document, savedDocument);
+
+            // update
+            var updated = UpdateAndAssert (document, savedDocument);
+
+            // delete
+            DeleteAndAssert (updated);
+        }
+
+        [Test]
+        public void testCreateDocumentWithAmpersand ()
+        {
+            var document = new DocumentRevision () {
+                docId = "my&document",
+                body = new Dictionary<string,Object> () {
+                    ["hello" ] = "world"
+                }
+            };
+
+            var savedDocument = CreateAndAssert (document);
+
+            //read
+            ReadAndAssert (document, savedDocument);
+
+            // update
+            var updated = UpdateAndAssert (document, savedDocument);
+
+            // delete
+            DeleteAndAssert (updated);
+        }
+
+        [Test]
+        public void testCreateDocumentWithRoundBrackets ()
+        {
+            var document = new DocumentRevision () {
+                docId = "my(document)",
+                body = new Dictionary<string,Object> () {
+                    ["hello" ] = "world"
+                }
+            };
+
+            var savedDocument = CreateAndAssert (document);
+
+            //read
+            ReadAndAssert (document, savedDocument);
+
+            // update
+            var updated = UpdateAndAssert (document, savedDocument);
+
+            // delete
+            DeleteAndAssert (updated);
+        }
+
+
+        [Test]
+        public void testCreateDocumentWithEquals ()
+        {
+            var document = new DocumentRevision () {
+                docId = "my=document",
+                body = new Dictionary<string,Object> () {
+                    ["hello" ] = "world"
+                }
+            };
+
+            var savedDocument = CreateAndAssert (document);
+
+            //read
+            ReadAndAssert (document, savedDocument);
+
+            // update
+            var updated = UpdateAndAssert (document, savedDocument);
+
+            // delete
+            DeleteAndAssert (updated);
+        }
+
+        [Test]
+        public void testCreateDocumentWithSemiColon ()
+        {
+            var document = new DocumentRevision () {
+                docId = "my;document",
+                body = new Dictionary<string,Object> () {
+                    ["hello" ] = "world"
+                }
+            };
+
+            var savedDocument = CreateAndAssert (document);
+
+            //read
+            ReadAndAssert (document, savedDocument);
+
+            // update
+            var updated = UpdateAndAssert (document, savedDocument);
+
+            // delete
+            DeleteAndAssert (updated);
+        }
+
+        [Test]
+        public void testCreateDocumentWithComma ()
+        {
+            var document = new DocumentRevision () {
+                docId = "my,document",
+                body = new Dictionary<string,Object> () {
+                    ["hello" ] = "world"
+                }
+            };
+
+            var savedDocument = CreateAndAssert (document);
+
+            //read
+            ReadAndAssert (document, savedDocument);
+
+            // update
+            var updated = UpdateAndAssert (document, savedDocument);
+
+            // delete
+            DeleteAndAssert (updated);
+        }
+
+        [Test]
+        public void testCreateDocumentWithPlus ()
+        {
+            var document = new DocumentRevision () {
+                docId = "my+document",
+                body = new Dictionary<string,Object> () {
+                    ["hello" ] = "world"
+                }
+            };
+
+            var savedDocument = CreateAndAssert (document);
+
+            //read
+            ReadAndAssert (document, savedDocument);
+
+            // update
+            var updated = UpdateAndAssert (document, savedDocument);
+
+            // delete
+            DeleteAndAssert (updated);
+        }
+
+        [Test]
+        public void testCreateDocumentWithStar ()
+        {
+            var document = new DocumentRevision () {
+                docId = "my*document",
+                body = new Dictionary<string,Object> () {
+                    ["hello" ] = "world"
+                }
+            };
+
+            var savedDocument = CreateAndAssert (document);
+
+            //read
+            ReadAndAssert (document, savedDocument);
+
+            // update
+            var updated = UpdateAndAssert (document, savedDocument);
+
+            // delete
+            DeleteAndAssert (updated);
+        }
+
+        [Test]
+        public void testCreateDocumentWithExclamation ()
+        {
+            var document = new DocumentRevision () {
+                docId = "my!document",
+                body = new Dictionary<string,Object> () {
+                    ["hello" ] = "world"
+                }
+            };
+
+            var savedDocument = CreateAndAssert (document);
+
+            //read
+            ReadAndAssert (document, savedDocument);
+
+            // update
+            var updated = UpdateAndAssert (document, savedDocument);
+
+            // delete
+            DeleteAndAssert (updated);
+        }
+
+
+
         // Private helpers
+
+        private DocumentRevision CreateAndAssert (DocumentRevision document)
+        {
+            Task<DocumentRevision> task = db.Create (document);
+            task.Wait ();
+            Assert.IsFalse (task.IsFaulted);
+            Assert.IsNotNull (task.Result);
+            var savedDocument = task.Result;
+
+            Assert.AreEqual (document.docId, savedDocument.docId);
+            Assert.AreEqual (document.body, savedDocument.body);
+
+            return savedDocument;
+        }
+
+        private void ReadAndAssert (DocumentRevision document, DocumentRevision savedDocument)
+        {
+            var readDocumentTask = db.Read (document.docId);
+            readDocumentTask.Wait ();
+            Assert.IsFalse (readDocumentTask.IsFaulted);
+            Assert.AreEqual (savedDocument, readDocumentTask.Result);
+        }
+
+        private DocumentRevision UpdateAndAssert (DocumentRevision document, DocumentRevision savedDocument)
+        {
+            savedDocument.body.Add ("updated", true);
+            var updateTask = db.Update (savedDocument);
+            updateTask.Wait ();
+            Assert.IsFalse (updateTask.IsFaulted);
+            Assert.AreEqual (document.docId, updateTask.Result.docId);
+            return updateTask.Result;
+        }
+
+        private void DeleteAndAssert (DocumentRevision updated)
+        {
+            var deleteTask = db.Delete (updated);
+            deleteTask.Wait ();
+            Assert.IsFalse (deleteTask.IsFaulted);
+        }
+
+
         private void doQuerySetupWithFields (String indexName, List<IndexField> indexFields)
         {
 
@@ -382,6 +811,10 @@ namespace Test.Shared
             doQuerySetupWithFields (ageIndex, ageIndexFields);
         }
 
+
+
     }
+
+
 }
 

--- a/src/Test.Shared/TestConstants.cs
+++ b/src/Test.Shared/TestConstants.cs
@@ -20,7 +20,7 @@ namespace Test.Shared
         /// The cloudant.com account hostname to connect to. For example
         /// sampleaccount.cloudant.com or http://sampleaccount.cloudant.com:1234
         /// </summary>
-        public static readonly string account =  "your-cloudant-account";
+        public static readonly string account = "your-cloudant-account-name";
 
         /// <summary>
         /// The cloudant user ID.
@@ -42,22 +42,24 @@ namespace Test.Shared
         /// <summary>
         /// Initializes the <see cref="Test.Shared.TestConstants"/> class and validates the required test settings have been configured.
         /// </summary>
-        static TestConstants(){
+        static TestConstants ()
+        {
 
             validateTestSettings ();
         }
-            
-        public static void validateTestSettings(){
-            if(    string.IsNullOrWhiteSpace(account)   || account.StartsWith("your-cloudant") 
-                || string.IsNullOrWhiteSpace(username)      || username.StartsWith("your-cloudant") 
-                || string.IsNullOrWhiteSpace(password)  || password.StartsWith("your-cloudant")){
+
+        public static void validateTestSettings ()
+        {
+            if (string.IsNullOrWhiteSpace (account) || account.StartsWith ("your-cloudant")
+                || string.IsNullOrWhiteSpace (username) || username.StartsWith ("your-cloudant")
+                || string.IsNullOrWhiteSpace (password) || password.StartsWith ("your-cloudant")) {
 
                 Console.Error.WriteLine ("!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!");
                 Console.Error.WriteLine ("!!! ERROR: Tests failed because you have not configured the Cloudant !!!");
                 Console.Error.WriteLine ("!!!        account, username, or password in TestConstants.cs        !!!"); 
                 Console.Error.WriteLine ("!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!");
 
-                throw new Exception("Tests failed because you have not configured your Cloudant account, username, or password in TestConstants.cs");
+                throw new Exception ("Tests failed because you have not configured your Cloudant account, username, or password in TestConstants.cs");
             }
         }
 


### PR DESCRIPTION
## What

Add tests for document ids with special meaning in urls, such as
`$`, `=` and `:`

Also added fixes to escaping the URL to make the tests pass.
## Reviewers

reviewer @ricellis 
reviewer @emlaver 
## Issues

Fixes #14
