### PR TITLE
Strip user info from URI

### DIFF
--- a/src/CloudantClient.PCL/src/CloudantClientBuilder.cs
+++ b/src/CloudantClient.PCL/src/CloudantClientBuilder.cs
@@ -86,7 +86,18 @@ namespace IBM.Cloudant.Client
             if (!accountUri.IsAbsoluteUri || accountUri.IsFile) {
                 throw new ArgumentException ("The 'accountUri' argument must be an absolute URI and must be a network location.", "accountUri");
             }
-            this.accountUri = accountUri;
+
+            // Strip the userinfo and fill the username and password field
+            var builder = new UriBuilder (accountUri);
+            if (builder.UserName != null) {
+                this.username = builder.UserName;
+                builder.UserName = null;
+            }
+            if (builder.Password != null) {
+                this.password = builder.Password;
+                builder.Password = null;
+            }
+            this.accountUri = builder.Uri;
         }
 
 

--- a/src/Test.Shared/CloudantClientTests.cs
+++ b/src/Test.Shared/CloudantClientTests.cs
@@ -213,6 +213,22 @@ namespace Test.Shared
                 new CloudantClientBuilder ("my.account.com").GetResult ();
             });
         }
+
+        [Test ()]
+        public void BuilderStripsUserNameAndPassword ()
+        {
+            var builder = new CloudantClientBuilder (new Uri ("https://username:password@username.cloudant.com"));
+            Assert.AreEqual ("username", builder.username);
+            Assert.AreEqual ("password", builder.password);
+            Assert.AreEqual (new Uri ("https://username.cloudant.com"), builder.accountUri);
+        }
+
+        [Test ()]
+        public void BuilderPassesThroughURIWithNoCreds ()
+        {
+            var builder = new CloudantClientBuilder (new Uri ("https://username.cloudant.com"));
+            Assert.AreEqual (new Uri ("https://username.cloudant.com"), builder.accountUri);
+        }
     }
 
 }


### PR DESCRIPTION
## What

Strip user info from the URI to the server in the CloudantClientBuilder, and use it populate the username and password field.
## Testing

One new test added to CloudantClientTests.
## Reviewers

reviewer @mikerhodes
## Issues

Resolves #18
