### PR TITLE
Use `await` and `async` keywords in methods.

### DIFF
--- a/src/CloudantClient.PCL/src/internal/http/HttpHelper.cs
+++ b/src/CloudantClient.PCL/src/internal/http/HttpHelper.cs
@@ -28,8 +28,9 @@ namespace IBM.Cloudant.Client
     /// </remarks>
     public class HttpHelper : IHttpHelper
     {
-        private HttpClient client = new HttpClient (new HttpClientHandler (){ UseCookies = false });// By setting UseCookies = false, we allow
-                                                                                            // interceptors to set the Cookie header.
+        private HttpClient client = new HttpClient(new HttpClientHandler(){ UseCookies = false });
+        // By setting UseCookies = false, we allow
+        // interceptors to set the Cookie header.
         /// <summary>
         /// List of interceptors that apply to http requests made by this HttpHelper instance.
         /// </summary>
@@ -50,7 +51,8 @@ namespace IBM.Cloudant.Client
         /// Initializes a new instance of the <see cref="Com.Cloudant.Client.Internal.Http.HttpHelper"/> class.
         /// </summary>
         /// <param name="baseUri">Base URI for the HttpClient in this helper. All http requests must be relative to this URI.</param>
-        public HttpHelper (Uri baseUri){
+        public HttpHelper(Uri baseUri)
+        {
             client.BaseAddress = baseUri;
         }
 
@@ -60,8 +62,11 @@ namespace IBM.Cloudant.Client
         /// <param name="requestInterceptors">Request interceptors.</param>
         /// <param name="responseInterceptors">Response interceptors.</param>
         /// <param name="baseUri">Base URI for the HttpClient in this helper. All http requests must be relative to this URI.</param>
-        public HttpHelper(Uri baseUri, List<IHttpConnectionRequestInterceptor> requestInterceptors, List<IHttpConnectionResponseInterceptor> responseInterceptors){
-            Debug.WriteLine ("ENTRY HttpHelper: Constructor() - requestInterceptors: "+requestInterceptors+"  responseInterceptors: "+responseInterceptors);
+        public HttpHelper(Uri baseUri,
+                           List<IHttpConnectionRequestInterceptor> requestInterceptors,
+                           List<IHttpConnectionResponseInterceptor> responseInterceptors)
+        {
+            Debug.WriteLine("ENTRY HttpHelper: Constructor() - requestInterceptors: " + requestInterceptors + "  responseInterceptors: " + responseInterceptors);
             client.BaseAddress = baseUri;
             this.requestInterceptors = requestInterceptors;
             this.responseInterceptors = responseInterceptors;
@@ -70,9 +75,10 @@ namespace IBM.Cloudant.Client
         /// <summary>
         /// See: <see cref="Com.Cloudant.Client.Internal.Http.IHttpHelper.sendGet"/>
         /// </summary>
-        public Task<HttpResponseMessage> sendGet(Uri uri, Dictionary<String,String> headers){
-            Debug.WriteLine ("HttpHelper :: SendGet()");
-            return SendJSONRequest (HttpMethod.Get, uri, headers, null);
+        public Task<HttpResponseMessage> sendGet(Uri uri, Dictionary<String,String> headers)
+        {
+            Debug.WriteLine("HttpHelper :: SendGet()");
+            return SendJSONRequest(HttpMethod.Get, uri, headers, null);
         }
 
         /// <summary>
@@ -81,9 +87,10 @@ namespace IBM.Cloudant.Client
         /// <returns>An async Task wich once completed contains the resulting HttpResponseMessage.</returns>
         /// <param name="uri">URI for this request.</param>
         /// <param name="headers">Http headers for this request.</param>
-        public Task<HttpResponseMessage> sendDelete (Uri uri, Dictionary<String, String> headers){
-            Debug.WriteLine ("HttpHelper :: SendDelete()");
-            return SendJSONRequest (HttpMethod.Delete, uri, headers, null);
+        public Task<HttpResponseMessage> sendDelete(Uri uri, Dictionary<String, String> headers)
+        {
+            Debug.WriteLine("HttpHelper :: SendDelete()");
+            return SendJSONRequest(HttpMethod.Delete, uri, headers, null);
         }
 
         /// <summary>
@@ -93,9 +100,12 @@ namespace IBM.Cloudant.Client
         /// <param name="uri">URI for this request.</param>
         /// <param name="headers">Http headers for this request.</param>
         /// <param name="body">The request contents.</param>
-        public Task<HttpResponseMessage> sendPut (Uri uri, Dictionary<String, String> headers, Dictionary<String, Object> body){
-            Debug.WriteLine ("HttpHelper :: SendPut()");
-            return SendJSONRequest (HttpMethod.Put, uri, headers, body);
+        public Task<HttpResponseMessage> sendPut(Uri uri,
+                                                  Dictionary<String, String> headers,
+                                                  Dictionary<String, Object> body)
+        {
+            Debug.WriteLine("HttpHelper :: SendPut()");
+            return SendJSONRequest(HttpMethod.Put, uri, headers, body);
         }
 
 
@@ -106,9 +116,12 @@ namespace IBM.Cloudant.Client
         /// <param name="uri">URI for this request.</param>
         /// <param name="headers">Http headers for this request.</param>
         /// <param name="body">The request contents.</param>
-        public Task<HttpResponseMessage> sendPost (Uri uri, Dictionary<String, String> headers, Dictionary<String, Object> body){
-            Debug.WriteLine ("HttpHelper :: SendPost()");
-            return SendJSONRequest (HttpMethod.Post, uri, headers, body);
+        public Task<HttpResponseMessage> sendPost(Uri uri,
+                                                   Dictionary<String, String> headers,
+                                                   Dictionary<String, Object> body)
+        {
+            Debug.WriteLine("HttpHelper :: SendPost()");
+            return SendJSONRequest(HttpMethod.Post, uri, headers, body);
         }
 
         /// <summary>
@@ -116,7 +129,8 @@ namespace IBM.Cloudant.Client
         /// </summary>
         /// <param name="name">Header name.</param>
         /// <param name="value">Header value.</param>
-        public void addGlobalHeaders (string name, string value){
+        public void addGlobalHeaders(string name, string value)
+        {
             client.DefaultRequestHeaders.Add(name, value);
         }
 
@@ -124,8 +138,9 @@ namespace IBM.Cloudant.Client
         /// Removes a header from the HttpClient global headers.
         /// </summary>
         /// <param name="name">Name.</param>
-        public void removeGlobalHeader(string name){
-            client.DefaultRequestHeaders.Remove (name);
+        public void removeGlobalHeader(string name)
+        {
+            client.DefaultRequestHeaders.Remove(name);
         }
 
         /// <summary>
@@ -134,111 +149,130 @@ namespace IBM.Cloudant.Client
         /// flag to true.
         /// </summary>
         /// <param name="numberOfRetries">Number of retries.</param>
-        public void setNumberOfRetries(int numberOfRetries){
+        public void setNumberOfRetries(int numberOfRetries)
+        {
             this.numberOfRetries = numberOfRetries;
         }
 
 
 
-        private Task<HttpResponseMessage> SendJSONRequest(HttpMethod method, Uri uri, Dictionary<string, string> headers, Dictionary<string, Object> body){
+        private Task<HttpResponseMessage> SendJSONRequest(HttpMethod method,
+                                                           Uri uri,
+                                                           Dictionary<string, string> headers,
+                                                           Dictionary<string, Object> body)
+        {
 
-            Dictionary<string,string> actualHeaders = (headers == null) ? new Dictionary<string,string> () : new Dictionary<string,string> (headers);
-            actualHeaders.Add ("Accept", "application/json"); 
+            Dictionary<string,string> actualHeaders = (headers == null) ? new Dictionary<string,string>() : new Dictionary<string,string>(headers);
+            actualHeaders.Add("Accept", "application/json"); 
 
-            HttpContent content=null;
-            if (body != null) {
-                string json = JsonConvert.SerializeObject (body);
+            HttpContent content = null;
+            if (body != null)
+            {
+                string json = JsonConvert.SerializeObject(body);
 
-                content = new System.Net.Http.StringContent (json);
-                content.Headers.ContentType = MediaTypeHeaderValue.Parse("application/json; charset="+DEFAULT_CHARSET);    
+                content = new System.Net.Http.StringContent(json);
+                content.Headers.ContentType = MediaTypeHeaderValue.Parse("application/json; charset=" + DEFAULT_CHARSET);    
             }
-            return SendRequest(method,uri,actualHeaders,content);
+            return SendRequest(method, uri, actualHeaders, content);
         }
-            
 
 
-        private Task<HttpResponseMessage> SendRequest(HttpMethod method, Uri uri, Dictionary<string, string> headers, HttpContent content){
-            Debug.WriteLine ("HttpHelper:sendRequest()  METHOD:"+method);
+
+        private async Task<HttpResponseMessage> SendRequest(HttpMethod method,
+                                                             Uri uri,
+                                                             Dictionary<string, string> headers,
+                                                             HttpContent content)
+        {
+            Debug.WriteLine("HttpHelper:sendRequest()  METHOD:" + method);
 
             Boolean retry = true;
             int n = numberOfRetries;
 
-            Task<HttpResponseMessage> result = Task.Run( () => {
-                while (retry && n-- > 0) {
-                    retry = false;
+            while (retry && n-- > 0)
+            {
+                retry = false;
 
-                    using (var request = new System.Net.Http.HttpRequestMessage (method, uri)) {
+                using (var request = new System.Net.Http.HttpRequestMessage(method, uri))
+                {
 
-                        if (headers != null) {
-                            foreach (KeyValuePair<string,string> item in headers) { 
+                    if (headers != null)
+                    {
+                        foreach (KeyValuePair<string,string> item in headers)
+                        { 
 
-                                request.Headers.TryAddWithoutValidation(item.Key, item.Value);  
-                            }
-                        }
-                
-                        request.Content = content;
-
-                            
-                        //Call request interceptors
-                        HttpConnectionInterceptorContext currHttpConnContext = new HttpConnectionInterceptorContext (request, null);
-
-                        foreach (IHttpConnectionRequestInterceptor requestInterceptor in requestInterceptors) {
-                            currHttpConnContext = requestInterceptor.InterceptRequest (currHttpConnContext);
-                        }
-
-
-                        //Process the request
-                        try {
-                            Debug.WriteLine (FormatHttpRequestLog (request));
-
-                            HttpResponseMessage response = client.SendAsync (request).Result as HttpResponseMessage;
-                            Debug.WriteLine (FormatHttpResponseLog (response));
-
-                            //Call response interceptors
-                            currHttpConnContext.responseMsg = response;
-                            foreach (IHttpConnectionResponseInterceptor responseInterceptor in responseInterceptors) {
-                                currHttpConnContext = responseInterceptor.InterceptResponse (currHttpConnContext);
-                            }
-                                
-                            retry = currHttpConnContext.replayRequest;
-
-                            if(!retry)
-                                return response;
-                                
-                        } catch (AggregateException ae) {
-                            Debug.WriteLine ("=== Sent request, got EXCEPTION response. Message: " + ae.GetBaseException().Message);
-                            throw ae.GetBaseException();
+                            request.Headers.TryAddWithoutValidation(item.Key, item.Value);  
                         }
                     }
-                }
-
-                Debug.WriteLine ("Maximum number of retries reached");
-                throw new Exception ("Maximum number of retries reached.  An HttpConnectionResponseInterceptor has set the replayRequest " +
-                    "flag to true, but the maximum number of retries ["+numberOfRetries+"] has been reached.");
-            });
                 
-            return result;
+                    request.Content = content;
+
+                            
+                    //Call request interceptors
+                    HttpConnectionInterceptorContext currHttpConnContext = new HttpConnectionInterceptorContext(
+                                                                               request,
+                                                                               null);
+
+                    foreach (IHttpConnectionRequestInterceptor requestInterceptor in requestInterceptors)
+                    {
+                        currHttpConnContext = requestInterceptor.InterceptRequest(currHttpConnContext);
+                    }
+
+
+                    //Process the request
+                    try
+                    {
+                        Debug.WriteLine(FormatHttpRequestLog(request));
+
+                        HttpResponseMessage response = await client.SendAsync(request).ConfigureAwait(continueOnCapturedContext: false);
+                        Debug.WriteLine(FormatHttpResponseLog(response));
+
+                        //Call response interceptors
+                        currHttpConnContext.responseMsg = response;
+                        foreach (IHttpConnectionResponseInterceptor responseInterceptor in responseInterceptors)
+                        {
+                            currHttpConnContext = responseInterceptor.InterceptResponse(currHttpConnContext);
+                        }
+                                
+                        retry = currHttpConnContext.replayRequest;
+
+                        if (!retry)
+                            return response;
+                                
+                    }
+                    catch (AggregateException ae)
+                    {
+                        Debug.WriteLine("=== Sent request, got EXCEPTION response. Message: " + ae.GetBaseException().Message);
+                        throw ae.GetBaseException();
+                    }
+                }
+            }
+
+            Debug.WriteLine("Maximum number of retries reached");
+            throw new Exception("Maximum number of retries reached.  An HttpConnectionResponseInterceptor has set the replayRequest " +
+                "flag to true, but the maximum number of retries [" + numberOfRetries + "] has been reached.");
         }
 
 
 
 
-        private string FormatHttpRequestLog(HttpRequestMessage request){
-            string contentString = request.Content == null ? "null" : request.Content.ToString ();
-            return string.Format ("Http Request\n   {0,-10}:{1}\n   {2,-10}:{3}\n   {4,-10}:{5}\n   {6,-10}:{7}\n   {8,-10}:{9}", 
+        private string FormatHttpRequestLog(HttpRequestMessage request)
+        {
+            string contentString = request.Content == null ? "null" : request.Content.ToString();
+            return string.Format("Http Request\n   {0,-10}:{1}\n   {2,-10}:{3}\n   {4,-10}:{5}\n   {6,-10}:{7}\n   {8,-10}:{9}", 
                 "METHOD", request.Method,
-                "URI", SanitizeUri (new Uri(client.BaseAddress, request.RequestUri)),
-                "HEADERS", FormatAndSanitizeHeaders (request.Headers),
+                "URI", SanitizeUri(new Uri(client.BaseAddress, request.RequestUri)),
+                "HEADERS", FormatAndSanitizeHeaders(request.Headers),
                 "CONTENT", contentString,
-                "PROPERTIES",FormatProperties(request.Properties));
+                "PROPERTIES", FormatProperties(request.Properties));
         }
 
-        private string FormatHttpResponseLog(HttpResponseMessage response){
-            string contentString = response.Content == null ? "null" : response.Content.ToString ();
+        private string FormatHttpResponseLog(HttpResponseMessage response)
+        {
+            string contentString = response.Content == null ? "null" : response.Content.ToString();
             return string.Format("Http Response\n   {0,-8}:[{1}] {2}\n   {3,-8}:{4}\n   {5,-8}:{6}\n   {7,-8}:{8}",
                 "URI", response.RequestMessage.Method, SanitizeUri(response.RequestMessage.RequestUri),
                 "STATUS", response.StatusCode,
-                "HEADERS",FormatAndSanitizeHeaders(response.Headers),
+                "HEADERS", FormatAndSanitizeHeaders(response.Headers),
                 "CONTENT", contentString);
         }
 
@@ -247,11 +281,13 @@ namespace IBM.Cloudant.Client
         /// </summary>
         /// <returns>A URI string there the user credentials have been removed.</returns>
         /// <param name="uri">URI.</param>
-        private string SanitizeUri(Uri uri){
-            if(uri.IsAbsoluteUri && uri.UserInfo != null && uri.UserInfo.Length > 0) {
-                return uri.Scheme + "://[USER]:[PASS]@" + uri.ToString ().Substring (uri.ToString ().IndexOf (uri.Host));
+        private string SanitizeUri(Uri uri)
+        {
+            if (uri.IsAbsoluteUri && uri.UserInfo != null && uri.UserInfo.Length > 0)
+            {
+                return uri.Scheme + "://[USER]:[PASS]@" + uri.ToString().Substring(uri.ToString().IndexOf(uri.Host));
             }
-            return uri.ToString ();
+            return uri.ToString();
         }
 
         /// <summary>
@@ -259,25 +295,33 @@ namespace IBM.Cloudant.Client
         /// </summary>
         /// <returns>A string with the HttpHeaders where the user credentials have been replaced by ***** </returns>
         /// <param name="headers">Headers.</param>
-        private string FormatAndSanitizeHeaders(HttpHeaders headers){
+        private string FormatAndSanitizeHeaders(HttpHeaders headers)
+        {
             
             if (headers == null)
                 return "null";
 
             int count = 0;
             string result = string.Empty;            
-            foreach (KeyValuePair<String,IEnumerable<string>> header in headers) {
-                foreach (string value in header.Value) {
+            foreach (KeyValuePair<String,IEnumerable<string>> header in headers)
+            {
+                foreach (string value in header.Value)
+                {
                     if (header.Key == "Authorization")
-                        result += string.Format ("\n\t[{0}]{1} : {2}", count++, header.Key, value.Split (' ') [0] + " *****");
+                        result += string.Format(
+                            "\n\t[{0}]{1} : {2}",
+                            count++,
+                            header.Key,
+                            value.Split(' ')[0] + " *****");
                     else
-                        result += string.Format ("\n\t[{0}]{1} : {2}", count++, header.Key, value);
+                        result += string.Format("\n\t[{0}]{1} : {2}", count++, header.Key, value);
                 }
             }
             return result;
         }
 
-        private string FormatProperties(IDictionary<string, object> props){
+        private string FormatProperties(IDictionary<string, object> props)
+        {
 
             if (props == null)
                 return "null";
@@ -287,9 +331,10 @@ namespace IBM.Cloudant.Client
 
             string result = string.Empty;
             int count = 0;
-            foreach (string key in props.Keys) {
+            foreach (string key in props.Keys)
+            {
                 object value; 
-                props.TryGetValue (key, out value);
+                props.TryGetValue(key, out value);
                 result += string.Format("\n\t[{0}] {1} : {2}", count++, key, value);
             }
             return result;

--- a/src/Test.Shared/CloudantClientTests.cs
+++ b/src/Test.Shared/CloudantClientTests.cs
@@ -100,7 +100,7 @@ namespace Test.Shared
         {
             string DBName = "database_doesnt_exist";
             var db = client.Database (DBName);
-            Assert.Throws<AggregateException> (() => db.ListIndices ().Wait (),
+            Assert.Throws<DataException> (async () => await db.ListIndices (),
                 "Test failed checking that exception is thrown when a database doesn't exist.");
         }
 

--- a/src/Test.Shared/DatabaseCRUDTests.cs
+++ b/src/Test.Shared/DatabaseCRUDTests.cs
@@ -50,7 +50,7 @@ namespace Test.Shared
             // create the database
             try {
                 db = client.Database (DBName);
-                db.EnsureExists ();
+                db.EnsureExists ().Wait ();
                 Assert.NotNull (db);
             } catch (AggregateException ae) {
                 Assert.Fail ("Create remote database failed.  Cause: " + ae.Message);
@@ -382,7 +382,7 @@ namespace Test.Shared
             
             var db = client.Database ("my/database");
             try {
-                db.EnsureExists ();
+                db.EnsureExists ().Wait ();
 
                 var document = new DocumentRevision () {
                     docId = "my/document",

--- a/src/Test.Shared/IndexTests.cs
+++ b/src/Test.Shared/IndexTests.cs
@@ -35,7 +35,7 @@ namespace Test.Shared
 
             string DBName = "httphelpertests" + DateTime.Now.Ticks;
             db = client.Database (DBName);
-            db.EnsureExists ();
+            db.EnsureExists ().Wait ();
         }
 
         [TearDown]

--- a/src/Test.Shared/InterceptorsTests.cs
+++ b/src/Test.Shared/InterceptorsTests.cs
@@ -34,11 +34,12 @@ namespace Test.Shared
         {
             DBName = TestConstants.defaultDatabaseName + DateTime.Now.Ticks;
         }
-            
+
         [TearDown] //Runs after each test.
-        protected void tearDown() {
+        protected void tearDown ()
+        {
             if (db != null) {
-                Task deleteDBTask = db.Delete();
+                Task deleteDBTask = db.Delete ();
                 deleteDBTask.Wait ();
 
                 if (deleteDBTask.IsFaulted)
@@ -47,43 +48,47 @@ namespace Test.Shared
         }
 
         [Test]
-        public void testBasicAuthInterceptor() {
+        public void testBasicAuthInterceptor ()
+        {
             BasicAuthenticationInterceptor basicAuthInterceptor = new BasicAuthenticationInterceptor (TestConstants.username, TestConstants.password);
 
             client = new CloudantClientBuilder (TestConstants.account) {
-                interceptors = new List<IHttpConnectionInterceptor>(){basicAuthInterceptor}
+                interceptors = new List<IHttpConnectionInterceptor> (){ basicAuthInterceptor }
             }.GetResult ();
 
             db = client.Database (DBName);
 
-            Assert.DoesNotThrow( () => {
-                db.EnsureExists ();},
+            Assert.DoesNotThrow (async () => {
+                await db.EnsureExists ().ConfigureAwait (continueOnCapturedContext: false);
+            },
                 "Exception thrown while creating database using BasicAuth interceptor. ");
 
-            Assert.NotNull(db);
+            Assert.NotNull (db);
 
         }
 
         [Test]
-        public void testCookieInterceptor() {
+        public void testCookieInterceptor ()
+        {
             CookieInterceptor cookieInterceptor = new CookieInterceptor (TestConstants.username, TestConstants.password);
 
             client = new CloudantClientBuilder (TestConstants.account) {
-                interceptors = new List<IHttpConnectionInterceptor>(){cookieInterceptor}
+                interceptors = new List<IHttpConnectionInterceptor> (){ cookieInterceptor }
             }.GetResult ();
 
             db = client.Database (DBName);
 
-            Assert.DoesNotThrow( () => {
-                db.EnsureExists ();
-                },
+            Assert.DoesNotThrow (async () => {
+                await db.EnsureExists ().ConfigureAwait (continueOnCapturedContext: false);
+            },
                 "Exception thrown while creating database using cookie interceptor. ");
 
-            Assert.NotNull(db);
+            Assert.NotNull (db);
         }
 
         [Test]
-        public void negativeTests(){
+        public void negativeTests ()
+        {
             Assert.Throws<DataException> (() => {
                 new CloudantClientBuilder (TestConstants.account) {
                     interceptors = new List<IHttpConnectionInterceptor> (){ new BadInterceptor () }
@@ -93,8 +98,11 @@ namespace Test.Shared
 
     }
 
-    internal class BadInterceptor : IHttpConnectionInterceptor {
-        public BadInterceptor(){}
+    internal class BadInterceptor : IHttpConnectionInterceptor
+    {
+        public BadInterceptor ()
+        {
+        }
     }
 }
 


### PR DESCRIPTION
## What

Use the `async` and `await` keywords in methods.
## How
- Change the method signatures to contain the `aysnc` keyword.
- Simplify method implementation by using the `await` keyword to indicate that continuing execution relies on the result of another async method. This removes the need to use `ContinueWith` and `Wait` in method calls.
- API Change, EnsureExists becomes an Async method returning a `Task` instead of void.
## Testing

All tests pass, only some tests have been converted to use the `async` and `await` keywords.
## Reviewers

reviewer @tomblench 
reviewer @ricellis 
## Issues
#25
