### PR TITLE
Use Custom Json Serialisers and Deserialisers

### DIFF
--- a/src/CloudantClient.PCL/CloudantClient.PCL.csproj
+++ b/src/CloudantClient.PCL/CloudantClient.PCL.csproj
@@ -50,6 +50,11 @@
     <Compile Include="src\SortSyntax.cs" />
     <Compile Include="src\IndexType.cs" />
     <Compile Include="src\TextIndexField.cs" />
+    <Compile Include="src\DocumentRevisionConverter.cs" />
+    <Compile Include="src\QueryDocumentRevisionConverter.cs" />
+    <Compile Include="src\ListIndicesConverter.cs" />
+    <Compile Include="src\IndexConverter.cs" />
+    <Compile Include="src\SortFieldConverter.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />
   <Import Project="..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets" Condition="Exists('..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets')" />

--- a/src/CloudantClient.PCL/src/Database.cs
+++ b/src/CloudantClient.PCL/src/Database.cs
@@ -32,25 +32,8 @@ namespace IBM.Cloudant.Client
     /// </remarks>
     public class Database
     {
-        // Special document fields
-        private static readonly string DOC_ID = "_id";
-        private static readonly string DOC_REV = "_rev";
-        private static readonly string DOC_DELETED = "_deleted";
-
         // REST response fields
-        private static readonly string DOC_RESPONSE_ID = "id";
         private static readonly string DOC_RESPONSE_REV = "rev";
-
-        private static readonly string INDEX_NAME_JSON_KEY = "name";
-        //private static readonly string INDEX_FIELDS_JSON_KEY = "fields";
-        private static readonly string INDEX_TYPE_JSON_KEY = "type";
-        private static readonly string INDEX_TYPE_JSON_VALUE = "json";
-        private static readonly string INDEX_DESIGN_DOCUMENT_JSON_KEY = "ddoc";
-
-
-        private static readonly List<string> validTextFieldTypes = new List<string> () {
-            "string", "number", "boolean"  
-        };
 
         private CloudantClient client;
         private string dbNameUrlEncoded;
@@ -119,7 +102,7 @@ namespace IBM.Cloudant.Client
                 string errorMessage = String.Format(
                                           "Failed to delete remote database.\nHTTP_Status: {0}\nJSON Body: {1}",
                                           httpStatus,
-                                          JsonConvert.DeserializeObject<Dictionary<string, object>>(await response.Content.ReadAsStringAsync().ConfigureAwait(continueOnCapturedContext: false)));
+                                          Database.DeserializeObject<Dictionary<string, object>>(await response.Content.ReadAsStringAsync().ConfigureAwait(continueOnCapturedContext: false)));
                 throw new DataException (DataException.Database_DatabaseModificationFailure, errorMessage);
             } 
         }
@@ -143,8 +126,8 @@ namespace IBM.Cloudant.Client
             var uri = new Uri (dbNameUrlEncoded + "/" + encodedDocId, UriKind.Relative);
             Debug.WriteLine("reltive URL is: " + uri.ToString());
 
-            Dictionary<String,Object> payload = ConvertDocToJSONPayload(revision);
-            Debug.WriteLine("Create document payload is: " + JsonConvert.SerializeObject(payload));
+            var payload = Database.SerializeObject(revision);
+            Debug.WriteLine("Create document payload is: " + Database.SerializeObject(payload));
 
             // Send the HTTP request
             HttpResponseMessage response;
@@ -166,34 +149,9 @@ namespace IBM.Cloudant.Client
 
             // Read in the response JSON into a Dictionary
             var content = await response.Content.ReadAsStringAsync().ConfigureAwait(continueOnCapturedContext: false);
-            Dictionary<string, object> responseJSON = JsonConvert.DeserializeObject<Dictionary<string, object>>(content); 
-            Debug.WriteLine("response JSON:{0}", JsonConvert.SerializeObject(responseJSON));
-
-            Object documentId;
-            responseJSON.TryGetValue(DOC_RESPONSE_ID, out documentId);
-            if (documentId == null || documentId.Equals("")) {
-                string errorMessage = "\nJSON Response didn't contain a documentId.";
-                Debug.WriteLine(errorMessage);
-                throw new DataException (DataException.Database_SaveDocumentRevisionFailure, errorMessage);
-            }
-
-
-            Object revisionId;
-            responseJSON.TryGetValue(DOC_RESPONSE_REV, out revisionId);
-            if (revisionId == null || revisionId.Equals("")) {
-                var errorMessage = "\nJSON Response didn't contain a revisionId.";
-                Debug.WriteLine(errorMessage);
-                throw new DataException (DataException.Database_SaveDocumentRevisionFailure, errorMessage);
-            }
-
-            // create new DocumentRevision with docId and revId returned
-            var createdDoc = new DocumentRevision ((string)documentId, (string)revisionId, payload);
-            Debug.WriteLine("returning DocumentRevision\n docId:{0}\n revId:{1}\n body:{2}",
-                documentId,
-                revisionId,
-                JsonConvert.SerializeObject(payload));
-
-            return createdDoc;
+            var document = Database.DeserializeObject<DocumentRevision>(content);
+            document.body = revision.body; //response doesn't contain document content
+            return document;
         }
 
         /// <summary>
@@ -231,9 +189,9 @@ namespace IBM.Cloudant.Client
                 revision.body = empty;
             }
 
-            Dictionary<String,Object> payload = ConvertDocToJSONPayload(revision);
+            var payload = Database.SerializeObject(revision);
 
-            Debug.WriteLine("Update document payload is: " + JsonConvert.SerializeObject(payload));
+            Debug.WriteLine("Update document payload is: " + Database.SerializeObject(payload));
             // Send the HTTP request
             var response = await client.httpHelper.sendPut(uri, null, payload).ConfigureAwait(continueOnCapturedContext: false);
 
@@ -248,33 +206,9 @@ namespace IBM.Cloudant.Client
 
             // Read in the response JSON into a Dictionary
             var content = await response.Content.ReadAsStringAsync().ConfigureAwait(continueOnCapturedContext: false);
-            var responseJSON = JsonConvert.DeserializeObject<Dictionary<string, object>>(content); 
-
-            Object documentId;
-            responseJSON.TryGetValue(DOC_RESPONSE_ID, out documentId);
-            if (documentId == null || documentId.Equals("")) {
-                string errorMessage = "\nJSON Response didn't contain a documentId.";
-                Debug.WriteLine(errorMessage);
-                throw new DataException (DataException.Database_SaveDocumentRevisionFailure, errorMessage);
-            }
-
-
-            Object revisionId;
-            responseJSON.TryGetValue(DOC_RESPONSE_REV, out revisionId);
-            if (revisionId == null || revisionId.Equals("")) {
-                string errorMessage = "\nJSON Response didn't contain a revisionId.";
-                Debug.WriteLine(errorMessage);
-                throw new DataException (DataException.Database_SaveDocumentRevisionFailure, errorMessage);
-            }
-
-            // create new DocumentRevision with docId and revId returned
-            var createdDoc = new DocumentRevision ((string)documentId, (string)revisionId, payload);
-            Debug.WriteLine("returning DocumentRevision\n docId:{0}\n revId:{1}\n body:{2}",
-                documentId,
-                revisionId,
-                JsonConvert.SerializeObject(payload));
-
-            return createdDoc;
+            var document = Database.DeserializeObject<DocumentRevision>(content);
+            document.body = revision.body; //response doesn't contain document content
+            return document;
         }
 
         /// <summary>
@@ -297,52 +231,21 @@ namespace IBM.Cloudant.Client
                 // Send the HTTP request
                 var response = await client.httpHelper.sendGet(requestUrl, null).ConfigureAwait(continueOnCapturedContext: false);
 
+                if (response.StatusCode != HttpStatusCode.OK) {
+                    // temp exception should be fixed as part of the common http handling issues #30 and #27
+                    throw new DataException (
+                        DataException.Database_FetchDocumentRevisionFailure,
+                        "Error occured reading document");
+                }
 
                 // Read in the response JSON into a Dictionary
                 var content = await response.Content.ReadAsStringAsync().ConfigureAwait(continueOnCapturedContext: false);
 
-                Dictionary<string, object> responseJSON = JsonConvert.DeserializeObject<Dictionary<string, object>>(content); 
 
-                Debug.WriteLine("Cloudant find document response.  Relative URI: " + requestUrl.ToString() + ". " +
-                    "Document: " + documentId + "\nResponse content:" + content);
+                Debug.WriteLine(content);
+                var document = Database.DeserializeObject<DocumentRevision>(content);
+                return document;
 
-                // Check the HTTP status code
-                var httpStatus = (int)response.StatusCode;
-                if (httpStatus != 200) {
-                    var errorMessage = String.Format("Failed to find document revision.\nRequest URL: {0}\nHTTP_Status: {1}\nJSONBody: {2}",
-                                           requestUrl.ToString(), httpStatus, content);
-                    Debug.WriteLine(errorMessage);
-                    throw new DataException (DataException.Database_FetchDocumentRevisionFailure, errorMessage);
-                }
-
-                Object responseDocumentId;
-                responseJSON.TryGetValue(DOC_ID, out responseDocumentId);
-                if (responseDocumentId == null || responseDocumentId.Equals("")) {
-                    string errorMessage = "\nJSON Response didn't contain a documentId.";
-                    Debug.WriteLine(errorMessage);
-                    throw new DataException (DataException.Database_FetchDocumentRevisionFailure, errorMessage);
-                }
-
-
-                Object responseRevisionId;
-                responseJSON.TryGetValue(DOC_REV, out responseRevisionId);
-                if (responseRevisionId == null || responseRevisionId.Equals("")) {
-                    string errorMessage = "\nJSON Response didn't contain a revisionId.";
-                    Debug.WriteLine(errorMessage);
-                    throw new DataException (DataException.Database_FetchDocumentRevisionFailure, errorMessage);
-                }
-
-                // create new DocumentRevision with docId and revId returned
-                var createdDoc = new DocumentRevision (
-                                     (string)responseDocumentId,
-                                     (string)responseRevisionId,
-                                     responseJSON);
-                Debug.WriteLine("returning DocumentRevision\n docId:{0}\n revId:{1}\n body:{2}",
-                    responseDocumentId,
-                    responseRevisionId,
-                    JsonConvert.SerializeObject(responseJSON));
-
-                return createdDoc;
             } catch (Exception e) {
                 throw new DataException (DataException.Database_FetchDocumentRevisionFailure, e.Message, e);
             }
@@ -371,7 +274,7 @@ namespace IBM.Cloudant.Client
 
                 // Read in the response JSON into a Dictionary
                 var content = await response.Content.ReadAsStringAsync().ConfigureAwait(continueOnCapturedContext: false);
-                Dictionary<string, object> responseJSON = JsonConvert.DeserializeObject<Dictionary<string, object>>(content); 
+                Dictionary<string, object> responseJSON = Database.DeserializeObject<Dictionary<string, object>>(content); 
 
                 Debug.WriteLine("Cloudant delete document response.  Relative URI: " + requestUrl.ToString() + ". " +
                     "Document: " + revision.docId + "\nResponse content:" + content);
@@ -523,17 +426,18 @@ namespace IBM.Cloudant.Client
             Uri indexUri = new Uri (dbNameUrlEncoded + "/_index", UriKind.Relative);
             Debug.WriteLine("index relative URI: " + indexUri);
 
-            var response = await client.httpHelper.sendPost(indexUri, null, indexDefinition).ConfigureAwait(continueOnCapturedContext: false);
+            var payload = Database.SerializeObject(indexDefinition);
+            var response = await client.httpHelper.sendPost(indexUri, null, payload).ConfigureAwait(continueOnCapturedContext: false);
 
             if (response.StatusCode == HttpStatusCode.OK || response.StatusCode == HttpStatusCode.Created) { //Status code 200 or 201
-                Debug.WriteLine(string.Format("Created Index: '{0}'", JsonConvert.SerializeObject(indexDefinition)));
+                Debug.WriteLine(string.Format("Created Index: '{0}'", Database.SerializeObject(indexDefinition)));
                 return;
             } else {
                 Debug.WriteLine(string.Format(
                         "Error creating index : '{0}'",
-                        JsonConvert.SerializeObject(indexDefinition)));
+                        Database.SerializeObject(indexDefinition)));
                 throw new DataException (DataException.Database_IndexModificationFailure,
-                    string.Format("Error creating index : '{0}'", JsonConvert.SerializeObject(indexDefinition))); 
+                    string.Format("Error creating index : '{0}'", Database.SerializeObject(indexDefinition))); 
             }
         }
 
@@ -613,8 +517,9 @@ namespace IBM.Cloudant.Client
                 
 
             Uri indexUri = new Uri (dbNameUrlEncoded + "/_find", UriKind.Relative);
+            var payload = Database.SerializeObject(body);
 
-            var response = await client.httpHelper.sendPost(indexUri, null, body).ConfigureAwait(continueOnCapturedContext: false);
+            var response = await client.httpHelper.sendPost(indexUri, null, payload).ConfigureAwait(continueOnCapturedContext: false);
 
             // Check the HTTP status code
             int httpStatus = (int)response.StatusCode;
@@ -627,94 +532,31 @@ namespace IBM.Cloudant.Client
 
             // Read in the response JSON into a Dictionary
             var content = await response.Content.ReadAsStringAsync().ConfigureAwait(continueOnCapturedContext: false);
-            Dictionary<string, object> responseJSON = JsonConvert.DeserializeObject<Dictionary<string, object>>(content); 
-            Debug.WriteLine("response JSON:{0}", JsonConvert.SerializeObject(responseJSON));
 
-            IList<DocumentRevision> documentList = new List<DocumentRevision> ();
-            Object documents;
-            responseJSON.TryGetValue("docs", out documents);
-            JArray doclist = (JArray)documents;
-            foreach (JToken token in doclist) {
-                String documentId = token.Value<String>(DOC_ID);
-                if (documentId == null || documentId.Equals("")) {
-                    string errorMessage = "\nJSON Response didn't contain a documentId.";
-                    Debug.WriteLine(errorMessage);
-                    throw new DataException (DataException.Database_SaveDocumentRevisionFailure, errorMessage);
-                }
+            var docs = Database.DeserializeObject<IList<DocumentRevision>>(content);
+            return docs;
 
-                String revisionId = token.Value<String>(DOC_REV);
-                if (revisionId == null || revisionId.Equals("")) {
-                    string errorMessage = "\nJSON Response didn't contain a revisionId.";
-                    Debug.WriteLine(errorMessage);
-                    throw new DataException (DataException.Database_SaveDocumentRevisionFailure, errorMessage);
-                }
-
-                // create new DocumentRevision with docId and revId returned
-                var documentBody = token.ToObject<Dictionary<String,Object>>();
-                DocumentRevision createdDoc = new DocumentRevision (documentId, revisionId, documentBody);
-                Debug.WriteLine("findByIndex() : adding DocumentRevision\n docId:{0}\n revId:{1}\n body:{2}",
-                    documentId,
-                    revisionId,
-                    JsonConvert.SerializeObject(documentBody));
-
-                documentList.Add(createdDoc);
-            }
-
-            return documentList;
         }
 
         /// <summary>
         /// Lists all indices.
         /// </summary>
         /// <returns>List of Index</returns>
-        public async Task<List<Index>> ListIndices ()
+        public async Task<IList<Index>> ListIndices ()
         {
-
-            List<Index> taskResult = new List<Index> ();
 
             Uri indexUri = new Uri (dbNameUrlEncoded + "/_index/", UriKind.Relative);
 
             var response = await client.httpHelper.sendGet(indexUri, null).ConfigureAwait(continueOnCapturedContext: false);
 
-            JObject jsonIndex = JsonConvert.DeserializeObject<JObject>(await response.Content.ReadAsStringAsync().ConfigureAwait(continueOnCapturedContext: false));
 
-            JToken indexes;
-            jsonIndex.TryGetValue("indexes", out indexes);
+            if (response.StatusCode != HttpStatusCode.OK) {
+                //temp exception, future PR for issues #30 and #27 will fix this
+                throw new DataException (-1, "Failed to list database indices"); 
+            }
 
-            if (indexes is Newtonsoft.Json.Linq.JArray) {
-                JArray indexesArray = (JArray)indexes;
-
-                foreach (JToken token in indexesArray) {
-                    Index index = new Index (token.SelectToken(INDEX_DESIGN_DOCUMENT_JSON_KEY).ToString(),
-                                      token.SelectToken(INDEX_NAME_JSON_KEY).ToString(), 
-                                      token.SelectToken(INDEX_TYPE_JSON_KEY).ToString());
-
-                    foreach (JObject indexArray in token.SelectToken("def.fields")) {
-
-                        foreach (JProperty prop in indexArray.Properties()) {
-                            var indexfield = new SortField ();
-                            indexfield.name = prop.Name;
-                            Sort sort = Sort.asc; // temp sort value to please compiler
-
-                            if (Enum.TryParse<Sort>(prop.Value.ToString(), out sort)) {
-                                indexfield.sort = sort;
-                                index.indexFields.Add(indexfield);
-                            } else {
-                                throw new DataException (DataException.Database_IndexModificationFailure,
-                                    "invalid index field sort order value.");
-                            }
-                        }
-                    }
-
-                    taskResult.Add(index);
-                } 
-            } else
-                throw new DataException (
-                    DataException.Database_IndexModificationFailure,
-                    "Got unexpected JSON for indexes. " + jsonIndex.ToString());
-
-            return taskResult;
-
+            var content = await response.Content.ReadAsStringAsync().ConfigureAwait(continueOnCapturedContext: false);
+            return Database.DeserializeObject < IList<Index>>(content);
         }
 
 
@@ -762,35 +604,25 @@ namespace IBM.Cloudant.Client
 
         // ======== PRIVATE HELPERS =============
 
-        private Dictionary<String,Object> ConvertDocToJSONPayload (DocumentRevision rev)
+        private static T DeserializeObject<T> (string json)
         {
-            Debug.WriteLine("==== enter Database::convertDocToJSONPayload(DocumentRevision)");
-            Dictionary<String,Object> result = new Dictionary<String, object> ();
+            return JsonConvert.DeserializeObject<T>(json, Database.converters());
+        }
 
-            if (rev.isDeleted) {
-                Debug.WriteLine("adding key:{0} value:true", DOC_DELETED);
-                result.Add(DOC_DELETED, true);
-            }
+        private static string SerializeObject (object obj)
+        {
+            return JsonConvert.SerializeObject(obj, Database.converters());
+        }
 
-            if (rev.docId != null) {
-                Debug.WriteLine("adding key:{0} value:{1}", DOC_ID, rev.docId);
-                result.Add(DOC_ID, rev.docId);
-            }
-
-            if (rev.revId != null) {
-                Debug.WriteLine("adding key:{0} value:{1}", DOC_REV, rev.revId);
-                result.Add(DOC_REV, rev.revId);
-            }
-
-            foreach (KeyValuePair<string,Object> entry in rev.body) {
-                Debug.WriteLine("document body key/value: {0}, {1}",
-                    entry.Key,
-                    entry.Value);
-                result.Add(entry.Key, entry.Value);
-            }
-
-            Debug.WriteLine("==== exit Database::convertDocToJSONPayload");
-            return result;
+        private static JsonConverter[] converters ()
+        {
+            return new JsonConverter[] {
+                new ListIndicesConverter (),
+                new QueryDocumentRevisionConverter (),
+                new SortFieldConverter (),
+                new DocumentRevisionConverter (),
+                new IndexConverter ()
+            };
         }
             
                         

--- a/src/CloudantClient.PCL/src/DocumentRevisionConverter.cs
+++ b/src/CloudantClient.PCL/src/DocumentRevisionConverter.cs
@@ -1,0 +1,100 @@
+﻿//
+//  Copyright (c) 2015 IBM Corp. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//  except in compliance with the License. You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software distributed under the
+//  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//  either express or implied. See the License for the specific language governing permissions 
+//  and limitations under the License.
+using System;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using System.Collections.Generic;
+
+namespace IBM.Cloudant.Client
+{
+    /// <summary>
+    /// Marshalls a <see cref="IBM.Cloudant.Client.DocumentRevision"/> object to and from JSON.
+    /// </summary>
+    internal class DocumentRevisionConverter : JsonConverter
+    {
+        public DocumentRevisionConverter ()
+        {
+        }
+
+
+        public override bool CanConvert (Type objectType)
+        {
+            return objectType == typeof(DocumentRevision);
+        }
+
+
+        public override object ReadJson (JsonReader reader,
+                                         Type objectType,
+                                         object existingValue,
+                                         JsonSerializer serializer)
+        {
+            var jsonObject = JObject.Load(reader);
+            var document = new DocumentRevision ();
+            document.body = new Dictionary<string,object> ();
+
+            foreach (var kv in jsonObject) {
+                switch (kv.Key) {
+                case "_id":
+                case "id":
+                    document.docId = kv.Value.ToObject<string>();
+                    break;
+                case "_rev":
+                case "rev":
+                    document.revId = kv.Value.ToObject<string>();
+                    break;
+                case "_deleted":
+                    document.isDeleted = kv.Value.ToObject<bool>();
+                    break;
+                default:
+                    // Other values go in the body
+                    document.body.Add(kv.Key, kv.Value.ToObject<dynamic>());
+                    break;
+                }
+            }
+                
+
+            return document;
+        }
+
+
+        public override void WriteJson (JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            var document = value as DocumentRevision;
+            writer.WriteStartObject();
+
+            if (document.docId != null) {
+                writer.WritePropertyName("_id");
+                serializer.Serialize(writer, document.docId);
+            }
+
+            if (document.revId != null) {
+                writer.WritePropertyName("_rev");
+                serializer.Serialize(writer, document.revId);
+            }
+            if (document.isDeleted) {
+                writer.WritePropertyName("_deleted");
+                serializer.Serialize(writer, document.isDeleted);
+            }
+
+            foreach (var pair in document.body) {
+                writer.WritePropertyName(pair.Key);
+                serializer.Serialize(writer, pair.Value);
+            }
+
+            writer.WriteEnd();
+        }
+
+
+    }
+}
+

--- a/src/CloudantClient.PCL/src/IndexConverter.cs
+++ b/src/CloudantClient.PCL/src/IndexConverter.cs
@@ -1,0 +1,78 @@
+﻿//
+//  Copyright (c) 2015 IBM Corp. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//  except in compliance with the License. You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software distributed under the
+//  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//  either express or implied. See the License for the specific language governing permissions 
+//  and limitations under the License.
+using System;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using System.Collections.Generic;
+
+namespace IBM.Cloudant.Client
+{
+    /// <summary>
+    /// Converts a JSON Query index definition to a <see cref="IBM.Cloudant.Client.Index"/> object.
+    /// </summary>
+    internal class IndexConverter : JsonConverter
+    {
+        public IndexConverter ()
+        {
+        }
+
+
+        public override bool CanConvert (Type objectType)
+        {
+            return objectType == typeof(Index);
+        }
+
+
+        public override object ReadJson (JsonReader reader,
+                                         Type objectType,
+                                         object existingValue,
+                                         JsonSerializer serializer)
+        {
+            var jsonObject = JObject.Load(reader);
+            IList<SortField> sortFields = new List<SortField> ();
+
+            var designDoc = jsonObject.GetValue("ddoc").ToObject<string>();
+            var name = jsonObject.GetValue("name").ToObject<string>();
+            var type = jsonObject.GetValue("type").ToObject<string>();
+
+            var def = jsonObject.GetValue("def") as JObject;
+
+            var indexFields = def.GetValue("fields");
+
+            foreach (var field in indexFields) {
+                var sortField = serializer.Deserialize<SortField>(field.CreateReader());
+                sortFields.Add(sortField);         
+            }
+
+            var index = new Index (designDoc, name, type);
+            index.indexFields.AddRange(sortFields);
+
+            return index;
+        }
+
+
+        public override void WriteJson (JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            throw new NotSupportedException ();
+        }
+
+        public override bool CanWrite {
+            get {
+                return false;
+            }
+        }
+
+
+    }
+}
+

--- a/src/CloudantClient.PCL/src/ListIndicesConverter.cs
+++ b/src/CloudantClient.PCL/src/ListIndicesConverter.cs
@@ -1,0 +1,66 @@
+﻿//
+//  Copyright (c) 2015 IBM Corp. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//  except in compliance with the License. You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software distributed under the
+//  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//  either express or implied. See the License for the specific language governing permissions 
+//  and limitations under the License.
+using System;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using System.Collections.Generic;
+
+namespace IBM.Cloudant.Client
+{
+    /// <summary>
+    /// Marshals a list of <see cref="IBM.Cloudant.client.Index"/> objects from json.
+    /// </summary>
+    internal class ListIndicesConverter : JsonConverter
+    {
+        public ListIndicesConverter ()
+        {
+        }
+
+        public override bool CanConvert (Type objectType)
+        {
+            return objectType == typeof(IList<Index>);
+        }
+
+
+        public override object ReadJson (JsonReader reader,
+                                         Type objectType,
+                                         object existingValue,
+                                         JsonSerializer serializer)
+        {
+            var jsonObject = JObject.Load(reader);
+            IList<Index> indexes = new List<Index> ();
+
+            var indexJsonObject = jsonObject.GetValue("indexes");
+            foreach (var obj in indexJsonObject) {
+                var indexReader = obj.CreateReader();
+                var index = serializer.Deserialize<Index>(indexReader);
+                indexes.Add(index);
+            }
+
+            return indexes;
+        }
+
+
+        public override bool CanWrite {
+            get {
+                return false;
+            }
+        }
+
+        public override void WriteJson (JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            throw new NotSupportedException ();
+        }
+    }
+}
+

--- a/src/CloudantClient.PCL/src/QueryDocumentRevisionConverter.cs
+++ b/src/CloudantClient.PCL/src/QueryDocumentRevisionConverter.cs
@@ -1,0 +1,68 @@
+﻿//
+//  Copyright (c) 2015 IBM Corp. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//  except in compliance with the License. You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software distributed under the
+//  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//  either express or implied. See the License for the specific language governing permissions 
+//  and limitations under the License.
+using System;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using System.Collections.Generic;
+
+namespace IBM.Cloudant.Client
+{
+    /// <summary>
+    /// Marshalls a list of <see cref="IBM.Cloudant.Client.DocumentRevision"/> objects from JSON.
+    /// It expects the list of documents to be located in the <c>docs</c> field of the JSON.
+    /// </summary>
+    internal class QueryDocumentRevisionConverter : JsonConverter
+    {
+        public QueryDocumentRevisionConverter ()
+        {
+        }
+
+        public override bool CanConvert (Type objectType)
+        {
+            return objectType == typeof(IList<DocumentRevision>);
+        }
+
+
+        public override object ReadJson (JsonReader reader,
+                                         Type objectType,
+                                         object existingValue,
+                                         JsonSerializer serializer)
+        {
+            var jsonObject = JObject.Load(reader);
+            IList<DocumentRevision> documents = new List<DocumentRevision> ();
+
+            var docs = jsonObject.GetValue("docs");
+            foreach (var obj in docs) {
+                var docReader = obj.CreateReader();
+                var document = serializer.Deserialize<DocumentRevision>(docReader);
+                documents.Add(document);
+            }
+
+            return documents;
+        }
+
+        public override bool CanWrite {
+            get {
+                return false;
+            }
+        }
+
+
+        public override void WriteJson (JsonWriter writer, object value, JsonSerializer serializer)
+        {
+
+            throw new NotSupportedException ();
+        }
+    }
+}
+

--- a/src/CloudantClient.PCL/src/SortFieldConverter.cs
+++ b/src/CloudantClient.PCL/src/SortFieldConverter.cs
@@ -1,0 +1,70 @@
+﻿//
+//  Copyright (c) 2015 IBM Corp. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//  except in compliance with the License. You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software distributed under the
+//  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//  either express or implied. See the License for the specific language governing permissions 
+//  and limitations under the License.
+using System;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using System.Collections.Generic;
+
+namespace IBM.Cloudant.Client
+{
+    /// <summary>
+    /// Marshals SortSyntax JSON objects into <see cref="IBM.Cloudant.client.SortField"/> struct.
+    /// </summary>
+    public class SortFieldConverter : JsonConverter
+    {
+        public SortFieldConverter ()
+        {
+        }
+
+        /// <inheritdoc/>
+        public override bool CanConvert (Type objectType)
+        {
+            return objectType == typeof(SortField);
+        }
+
+        /// <inheritdoc/>
+        public override object ReadJson (JsonReader reader,
+                                         Type objectType,
+                                         object existingValue,
+                                         JsonSerializer serializer)
+        {
+            var jsonObject = JObject.Load(reader);
+
+            var jsonProperty = (JProperty)jsonObject.First;
+            var name = jsonProperty.Name;
+            var sort = (string)jsonProperty.Value;
+            Sort sortEnum;
+            if (Enum.TryParse(sort, out sortEnum)) {
+                return new SortField () { name = name, sort = sortEnum };
+            } else {
+                throw new DataException (-1, "Unexpected json for Sort Field");
+            }
+
+              
+        }
+
+        /// <inheritdoc/>
+        public override bool CanWrite {
+            get {
+                return false;
+            }
+        }
+
+        /// <inheritdoc/>
+        public override void WriteJson (JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            throw new NotSupportedException ();
+        }
+    }
+}
+

--- a/src/CloudantClient.PCL/src/internal/http/HttpHelper.cs
+++ b/src/CloudantClient.PCL/src/internal/http/HttpHelper.cs
@@ -8,7 +8,7 @@
 //
 //  Unless required by applicable law or agreed to in writing, software distributed under the
 //  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
-//  either express or implied. See the License for the specific language governing permissions 
+//  either express or implied. See the License for the specific language governing permissions
 //  and limitations under the License.
 using System;
 using System.Collections.Generic;
@@ -100,9 +100,9 @@ namespace IBM.Cloudant.Client
         /// <param name="uri">URI for this request.</param>
         /// <param name="headers">Http headers for this request.</param>
         /// <param name="body">The request contents.</param>
-        public Task<HttpResponseMessage> sendPut(Uri uri,
+        public Task<HttpResponseMessage> sendPut (Uri uri,
                                                   Dictionary<String, String> headers,
-                                                  Dictionary<String, Object> body)
+                                                  string body)
         {
             Debug.WriteLine("HttpHelper :: SendPut()");
             return SendJSONRequest(HttpMethod.Put, uri, headers, body);
@@ -116,9 +116,9 @@ namespace IBM.Cloudant.Client
         /// <param name="uri">URI for this request.</param>
         /// <param name="headers">Http headers for this request.</param>
         /// <param name="body">The request contents.</param>
-        public Task<HttpResponseMessage> sendPost(Uri uri,
+        public Task<HttpResponseMessage> sendPost (Uri uri,
                                                    Dictionary<String, String> headers,
-                                                   Dictionary<String, Object> body)
+                                                   string body)
         {
             Debug.WriteLine("HttpHelper :: SendPost()");
             return SendJSONRequest(HttpMethod.Post, uri, headers, body);
@@ -144,8 +144,8 @@ namespace IBM.Cloudant.Client
         }
 
         /// <summary>
-        /// Maximum number of times to rety a request when it has been intercepted and any interceptor sets 
-        /// the <see cref="Com.Cloudant.Client.Internal.Http.HttpConnectionInterceptorContext.replayRequest"/> 
+        /// Maximum number of times to rety a request when it has been intercepted and any interceptor sets
+        /// the <see cref="Com.Cloudant.Client.Internal.Http.HttpConnectionInterceptorContext.replayRequest"/>
         /// flag to true.
         /// </summary>
         /// <param name="numberOfRetries">Number of retries.</param>
@@ -159,19 +159,17 @@ namespace IBM.Cloudant.Client
         private Task<HttpResponseMessage> SendJSONRequest(HttpMethod method,
                                                            Uri uri,
                                                            Dictionary<string, string> headers,
-                                                           Dictionary<string, Object> body)
+                                                           string body)
         {
 
             Dictionary<string,string> actualHeaders = (headers == null) ? new Dictionary<string,string>() : new Dictionary<string,string>(headers);
-            actualHeaders.Add("Accept", "application/json"); 
+            actualHeaders.Add("Accept", "application/json");
 
             HttpContent content = null;
             if (body != null)
             {
-                string json = JsonConvert.SerializeObject(body);
-
-                content = new System.Net.Http.StringContent(json);
-                content.Headers.ContentType = MediaTypeHeaderValue.Parse("application/json; charset=" + DEFAULT_CHARSET);    
+                content = new System.Net.Http.StringContent(body);
+                content.Headers.ContentType = MediaTypeHeaderValue.Parse("application/json; charset=" + DEFAULT_CHARSET);
             }
             return SendRequest(method, uri, actualHeaders, content);
         }
@@ -198,15 +196,15 @@ namespace IBM.Cloudant.Client
                     if (headers != null)
                     {
                         foreach (KeyValuePair<string,string> item in headers)
-                        { 
+                        {
 
-                            request.Headers.TryAddWithoutValidation(item.Key, item.Value);  
+                            request.Headers.TryAddWithoutValidation(item.Key, item.Value);
                         }
                     }
-                
+
                     request.Content = content;
 
-                            
+
                     //Call request interceptors
                     HttpConnectionInterceptorContext currHttpConnContext = new HttpConnectionInterceptorContext(
                                                                                request,
@@ -232,12 +230,12 @@ namespace IBM.Cloudant.Client
                         {
                             currHttpConnContext = responseInterceptor.InterceptResponse(currHttpConnContext);
                         }
-                                
+
                         retry = currHttpConnContext.replayRequest;
 
                         if (!retry)
                             return response;
-                                
+
                     }
                     catch (AggregateException ae)
                     {
@@ -258,7 +256,7 @@ namespace IBM.Cloudant.Client
         private string FormatHttpRequestLog(HttpRequestMessage request)
         {
             string contentString = request.Content == null ? "null" : request.Content.ToString();
-            return string.Format("Http Request\n   {0,-10}:{1}\n   {2,-10}:{3}\n   {4,-10}:{5}\n   {6,-10}:{7}\n   {8,-10}:{9}", 
+            return string.Format("Http Request\n   {0,-10}:{1}\n   {2,-10}:{3}\n   {4,-10}:{5}\n   {6,-10}:{7}\n   {8,-10}:{9}",
                 "METHOD", request.Method,
                 "URI", SanitizeUri(new Uri(client.BaseAddress, request.RequestUri)),
                 "HEADERS", FormatAndSanitizeHeaders(request.Headers),
@@ -297,12 +295,12 @@ namespace IBM.Cloudant.Client
         /// <param name="headers">Headers.</param>
         private string FormatAndSanitizeHeaders(HttpHeaders headers)
         {
-            
+
             if (headers == null)
                 return "null";
 
             int count = 0;
-            string result = string.Empty;            
+            string result = string.Empty;
             foreach (KeyValuePair<String,IEnumerable<string>> header in headers)
             {
                 foreach (string value in header.Value)
@@ -333,7 +331,7 @@ namespace IBM.Cloudant.Client
             int count = 0;
             foreach (string key in props.Keys)
             {
-                object value; 
+                object value;
                 props.TryGetValue(key, out value);
                 result += string.Format("\n\t[{0}] {1} : {2}", count++, key, value);
             }

--- a/src/CloudantClient.PCL/src/internal/http/IHttpHelper.cs
+++ b/src/CloudantClient.PCL/src/internal/http/IHttpHelper.cs
@@ -48,7 +48,7 @@ namespace IBM.Cloudant.Client
         /// <param name="uri">URI for this request.</param>
         /// <param name="headers">Http headers for this request.</param>
         /// <param name="body">The request contents.</param>
-        Task<HttpResponseMessage> sendPut (Uri uri, Dictionary<String, String> headers, Dictionary<String, Object> body);
+        Task<HttpResponseMessage> sendPut (Uri uri, Dictionary<String, String> headers, string body);
 
         /// <summary>
         /// Sends an Http POST request to the given URI using the given headers and content.
@@ -57,7 +57,7 @@ namespace IBM.Cloudant.Client
         /// <param name="uri">URI for this request.</param>
         /// <param name="headers">Http headers for this request.</param>
         /// <param name="body">The request contents.</param>
-        Task<HttpResponseMessage> sendPost (Uri uri, Dictionary<String, String> headers, Dictionary<String, Object> body);
+        Task<HttpResponseMessage> sendPost (Uri uri, Dictionary<String, String> headers, string body);
 
         /// <summary>
         /// Adds global headers to be used by every request sent by this HttpHelper.

--- a/src/Test.Shared/DatabaseCRUDTests.cs
+++ b/src/Test.Shared/DatabaseCRUDTests.cs
@@ -201,14 +201,12 @@ namespace Test.Shared
         [Test]
         public void testInvalidFetchNonexistId ()
         {
-            try {
                 // fetch id that doesn't exist
+            Assert.Throws<AggregateException>(() => {
                 Task<DocumentRevision> fetchByIdTask = db.Read ("1234");
                 fetchByIdTask.Wait ();
-                Assert.True (fetchByIdTask.IsFaulted, "find should produce fault on find of empty string");
-            } catch (Exception e) {
-                Assert.Pass ("expected testInvalidFetchNonexistId exception caught.  Cause:" + e.InnerException.Message);
-            }
+
+                });   
         }
 
         [Test]

--- a/src/Test.Shared/HttpHelperTests.cs
+++ b/src/Test.Shared/HttpHelperTests.cs
@@ -17,6 +17,7 @@ using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
 using NUnit.Framework;
+using Newtonsoft.Json;
 
 using IBM.Cloudant.Client;
 
@@ -58,8 +59,12 @@ namespace Test.Shared
             content.Add ("stringKey", "nicestringvalue");
             content.Add ("numberKey", 42);
 
-            Task<HttpResponseMessage> postResponse = helper.sendPost (new Uri (DBName, UriKind.Relative), null, content);
-            postResponse.Wait ();
+            var payload = JsonConvert.SerializeObject(content);
+            Task<HttpResponseMessage> postResponse = helper.sendPost(
+                                                         new Uri (DBName, UriKind.Relative),
+                                                         null,
+                                                         payload);
+            postResponse.Wait();
 
             Debug.WriteLine ("POST response: " + postResponse.Result.StatusCode);
             Assert.AreEqual (HttpStatusCode.Created, postResponse.Result.StatusCode);


### PR DESCRIPTION
## What

Create and use custom JSON serialisers and deserialisers centralising the
JSON handling logic in one place.
## How
- Create Custom JSON serialisers and deserialisers
- Remove JSON processing logic from  the `Database` class
- Convert `HTTPHelper` methods to expect a string instead of a dictionary for the payload.
## Reviewers

reviewer @emlaver 
reviewer @mikerhodes
## Issues

Resolves #28
## Notes

The PR had to make some modifications to the HTTP results handling, the changes in serialisation changed where exceptions and error handling was taking place, this will be fixed in a later PR as part of work on #30 
