### PR TITLE
Append `Async` to all async methods in the Database class.

### DIFF
--- a/src/CloudantClient.PCL/src/Database.cs
+++ b/src/CloudantClient.PCL/src/Database.cs
@@ -1,4 +1,4 @@
-﻿//
+//
 //  Copyright (c) 2015 IBM Corp. All rights reserved.
 //
 //  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
@@ -70,7 +70,7 @@ namespace IBM.Cloudant.Client
 		/// <summary>
 		/// Ensures the database exists. 
 		/// </summary>
-		public async Task EnsureExists()
+		public async Task EnsureExistsAsync()
 		{
 			var dbUri = new Uri(client.accountUri.ToString() + dbNameUrlEncoded);
 			var response = await client.httpHelper.sendPut(dbUri, null, null).ConfigureAwait(continueOnCapturedContext: false);
@@ -90,8 +90,8 @@ namespace IBM.Cloudant.Client
 		/// <summary>
 		/// Deletes the database this object represents.
 		/// </summary>
-		/// <returns>A Task to mointor this action.</returns>
-		public async Task Delete()
+		/// <returns>A Task to monitor this action.</returns>
+		public async Task DeleteAsync()
 		{
 			var response = await client.httpHelper.sendDelete(
 				               new Uri(
@@ -114,7 +114,7 @@ namespace IBM.Cloudant.Client
 		/// Create the specified document in the database.
 		/// </summary>
 		/// <param name="revision">Revision to create.</param>
-		public async Task<DocumentRevision> Create(DocumentRevision revision)
+		public async Task<DocumentRevision> CreateAsync(DocumentRevision revision)
 		{
 			Debug.WriteLine("==== enter Database::Create(Object)");
 			if (revision == null)
@@ -169,7 +169,7 @@ namespace IBM.Cloudant.Client
 		/// 
 		/// </summary>
 		/// <param name="revisionToUpdate">Revision to update.</param>
-		public async Task<DocumentRevision> Update(DocumentRevision revision)
+		public async Task<DocumentRevision> UpdateAsync(DocumentRevision revision)
 		{
 			Debug.WriteLine("==== enter Database::update(Object)"); 
 			if (revision == null)
@@ -231,7 +231,7 @@ namespace IBM.Cloudant.Client
 		/// Reads the specified document, from the database.
 		/// </summary>
 		/// <param name="documentId">The id of the document to read.</param>
-		public async Task<DocumentRevision> Read(String documentId)
+		public async Task<DocumentRevision> ReadAsync(String documentId)
 		{
 			Debug.WriteLine("==== enter Database::Read(String)");
 			try
@@ -276,7 +276,7 @@ namespace IBM.Cloudant.Client
 		/// Delete the specified Document Revision.
 		/// </summary>
 		/// <param name="revision">Document revision to delete.</param>
-		public async Task<String> Delete(DocumentRevision revision)
+		public async Task<String> DeleteAsync(DocumentRevision revision)
 		{
 			Debug.WriteLine("==== enter Database::delete(Object)");
 
@@ -335,12 +335,12 @@ namespace IBM.Cloudant.Client
 		/// <param name="indexName"> Optional. The name to call this index, if ommited, CouchDB will generate the name for the index. </param>
 		/// <param name="designDocumentName"> Optional. The name of the design document to save this index definition</param>
 		/// <returns>A Task that represents the async operation</returns>
-		public async Task CreateJsonIndex(IList<SortField> fields,
-		                                  string indexName = null,
-		                                  string designDocumentName = null)
+		public async Task CreateJsonIndexAsync(IList<SortField> fields,
+		                                       string indexName = null,
+		                                       string designDocumentName = null)
 		{
 
-			//validate fields for sort syntax compilence
+			//validate fields for sort syntax compliance
 
 			var requestDict = new Dictionary<string, object>()
 			{
@@ -382,7 +382,7 @@ namespace IBM.Cloudant.Client
 				requestDict.Add("ddoc", designDocumentName);
 			}
                 
-			await this.CreateIndex(requestDict).ConfigureAwait(continueOnCapturedContext: false);
+			await this.CreateIndexAsync(requestDict).ConfigureAwait(continueOnCapturedContext: false);
 		}
 
 		/// <summary>
@@ -398,12 +398,12 @@ namespace IBM.Cloudant.Client
 		/// default_field needs to be enabled in order to use the<c>$text</c> operator in queries.</param>
 		/// <param name="defaultFieldAnalyzer">Optional, CouchDb will use the default analyzer if one is not specified. 
 		/// This specifies the anayalzer to use for $text query operations</param>
-		public async Task CreateTextIndex(IList<TextIndexField> fields = null,
-		                                  string indexName = null, 
-		                                  string designDocumentName = null,
-		                                  IDictionary<string,object> selector = null,
-		                                  Boolean defaultFieldEnabled = false,
-		                                  string defaultFieldAnalyzer = null)
+		public async Task CreateTextIndexAsync(IList<TextIndexField> fields = null,
+		                                       string indexName = null, 
+		                                       string designDocumentName = null,
+		                                       IDictionary<string,object> selector = null,
+		                                       Boolean defaultFieldEnabled = false,
+		                                       string defaultFieldAnalyzer = null)
 		{
 			var index = new Dictionary<string,object>();
 			var requestDict = new Dictionary<string, object>()
@@ -463,11 +463,11 @@ namespace IBM.Cloudant.Client
 
 			index.Add("default_field", default_field);
 
-			await this.CreateIndex(requestDict).ConfigureAwait(continueOnCapturedContext: false);
+			await this.CreateIndexAsync(requestDict).ConfigureAwait(continueOnCapturedContext: false);
 		}
 
 
-		private async Task CreateIndex(Dictionary<String,Object> indexDefinition)
+		private async Task CreateIndexAsync(Dictionary<String,Object> indexDefinition)
 		{
 			Uri indexUri = new Uri(dbNameUrlEncoded + "/_index", UriKind.Relative);
 			Debug.WriteLine("index relative URI: " + indexUri);
@@ -507,14 +507,14 @@ namespace IBM.Cloudant.Client
 		/// if ever, needed. It will be detrimental to performance </param>
 		/// <seealso href="https://docs.cloudant.com/cloudant_query.html#finding-documents-using-an-index">Cloudant 
 		/// Documentation</seealso>
-		public async Task<IList<DocumentRevision>> Query(IDictionary<string,object> selector,
-		                                                 IList<string> fields = null,
-		                                                 int limit = -1, 
-		                                                 int skip = -1,
-		                                                 IList<SortField> sort = null,
-		                                                 string bookmark = null,
-		                                                 string useIndex = null,
-		                                                 int r = -1)
+		public async Task<IList<DocumentRevision>> QueryAsync(IDictionary<string,object> selector,
+		                                                      IList<string> fields = null,
+		                                                      int limit = -1, 
+		                                                      int skip = -1,
+		                                                      IList<SortField> sort = null,
+		                                                      string bookmark = null,
+		                                                      string useIndex = null,
+		                                                      int r = -1)
 		{
 			if (selector == null)
 			{
@@ -606,7 +606,7 @@ namespace IBM.Cloudant.Client
 		/// Lists all indices.
 		/// </summary>
 		/// <returns>List of Index</returns>
-		public async Task<IList<Index>> ListIndices()
+		public async Task<IList<Index>> ListIndicesAsync()
 		{
 
 			Uri indexUri = new Uri(dbNameUrlEncoded + "/_index/", UriKind.Relative);
@@ -632,7 +632,7 @@ namespace IBM.Cloudant.Client
 		/// <param name="indexName">name of the index</param>
 		/// <param name="designDocId">ID of the design doc</param>
 		/// <param name="indexType">The type of index to delete</param>
-		public async Task DeleteIndex(String indexName, String designDocId, IndexType indexType)
+		public async Task DeleteIndexAsync(String indexName, String designDocId, IndexType indexType)
 		{
 
 			if (string.IsNullOrWhiteSpace(indexName))

--- a/src/Test.Shared/CloudantClientDatabaseTests.cs
+++ b/src/Test.Shared/CloudantClientDatabaseTests.cs
@@ -1,4 +1,4 @@
-﻿//
+//
 //  Copyright (c) 2015 IBM Corp. All rights reserved.
 //
 //  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
@@ -47,7 +47,7 @@ namespace Test.Shared
 		{
 			if (db != null)
 			{
-				db.Delete().Wait();
+				db.DeleteAsync().Wait();
 			}
 		}
 
@@ -57,8 +57,8 @@ namespace Test.Shared
 			db = client.Database(DBName);
 			Assert.DoesNotThrow(async () =>
 				{
-					await db.EnsureExists().ConfigureAwait(continueOnCapturedContext: false);
-					await db.EnsureExists().ConfigureAwait(continueOnCapturedContext: false);
+					await db.EnsureExistsAsync().ConfigureAwait(continueOnCapturedContext: false);
+					await db.EnsureExistsAsync().ConfigureAwait(continueOnCapturedContext: false);
 				});
 		}
 
@@ -67,7 +67,7 @@ namespace Test.Shared
 		{
             
 			db = client.Database(DBName);
-			db.EnsureExists().Wait();
+			db.EnsureExistsAsync().Wait();
 			Assert.NotNull(db);
 
 			//Test db names are url encoded
@@ -75,9 +75,9 @@ namespace Test.Shared
 			Assert.DoesNotThrow(async () =>
 				{
 					var newDb = client.Database(databaseName);
-					await newDb.EnsureExists().ConfigureAwait(continueOnCapturedContext: false);
+					await newDb.EnsureExistsAsync().ConfigureAwait(continueOnCapturedContext: false);
 					//Clean up
-					await newDb.Delete().ConfigureAwait(continueOnCapturedContext: false);
+					await newDb.DeleteAsync().ConfigureAwait(continueOnCapturedContext: false);
 				},
 				"Test failed to create a database with name " + databaseName);
 		}
@@ -99,7 +99,7 @@ namespace Test.Shared
 				Assert.Throws<DataException>(async () =>
 					{
 						var db = client.Database(name);
-						await db.EnsureExists().ConfigureAwait(continueOnCapturedContext: false);
+						await db.EnsureExistsAsync().ConfigureAwait(continueOnCapturedContext: false);
 					},
 					"Test failed because invalid database name {0} should have produced an error. ", new []{ name });
 			}
@@ -120,7 +120,7 @@ namespace Test.Shared
 				Assert.Throws<ArgumentException>(async () =>
 					{
 						var db = client.Database(name);
-						await db.EnsureExists().ConfigureAwait(continueOnCapturedContext: false);
+						await db.EnsureExistsAsync().ConfigureAwait(continueOnCapturedContext: false);
 					},
 					"Test failed because invalid database name {0} should have produced an error. ", new []{ name });
 			}

--- a/src/Test.Shared/CloudantClientTests.cs
+++ b/src/Test.Shared/CloudantClientTests.cs
@@ -1,4 +1,4 @@
-﻿//
+//
 //  Copyright (c) 2015 IBM Corp. All rights reserved.
 //
 //  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
@@ -96,17 +96,17 @@ namespace Test.Shared
 		}
 
 
-		/// <summary>
-		/// Test a NoDocumentException is thrown when trying an operation on a DB that doesn't exist.
-		/// </summary>
-		[Test()]
-		public void NonExistentDatabaseException()
-		{
-			string DBName = "database_doesnt_exist";
-			var db = client.Database(DBName);
-			Assert.Throws<DataException>(async () => await db.ListIndices(),
-				"Test failed checking that exception is thrown when a database doesn't exist.");
-		}
+        /// <summary>
+        /// Test a NoDocumentException is thrown when trying an operation on a DB that doesn't exist.
+        /// </summary>
+        [Test()]
+        public void NonExistentDatabaseException()
+        {
+            string DBName = "database_doesnt_exist";
+            var db = client.Database (DBName);
+            Assert.Throws<DataException>(async () => await db.ListIndicesAsync (),
+                "Test failed checking that exception is thrown when a database doesn't exist.");
+        }
 
 
 		/// <summary>

--- a/src/Test.Shared/DatabaseCRUDTests.cs
+++ b/src/Test.Shared/DatabaseCRUDTests.cs
@@ -1,4 +1,4 @@
-﻿//
+//
 //  Copyright (c) 2015 IBM Corp. All rights reserved.
 //
 //  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
@@ -52,7 +52,7 @@ namespace Test.Shared
 			try
 			{
 				db = client.Database(DBName);
-				db.EnsureExists().Wait();
+				db.EnsureExistsAsync().Wait();
 				Assert.NotNull(db);
 			}
 			catch (AggregateException ae)
@@ -70,7 +70,7 @@ namespace Test.Shared
 		{
 			if (db != null)
 			{
-				Task deleteTask = db.Delete();
+				Task deleteTask = db.DeleteAsync();
 				deleteTask.Wait();
 
 				if (deleteTask.IsFaulted)
@@ -100,7 +100,7 @@ namespace Test.Shared
 			DocumentRevision revision = new DocumentRevision();
 			revision.body = dictionary;
 
-			Task<DocumentRevision> task = db.Create(revision);
+			Task<DocumentRevision> task = db.CreateAsync(revision);
 			task.Wait();
 
 			// Validate save result
@@ -111,7 +111,7 @@ namespace Test.Shared
 			Assert.NotNull(savedRevision.revId, "savedRevision.revId == null");
 
 			// perform find
-			task = db.Read(savedRevision.docId);
+			task = db.ReadAsync(savedRevision.docId);
 			task.Wait();
 
 			// Validate find result
@@ -123,7 +123,7 @@ namespace Test.Shared
 			fetchedRevision.body.Remove(stringKey);
 
 			// perform update
-			task = db.Update(fetchedRevision);
+			task = db.UpdateAsync(fetchedRevision);
 			task.Wait();
 
 			Assert.False(task.IsFaulted, "update unexpectedly failed");
@@ -135,7 +135,7 @@ namespace Test.Shared
 			Assert.False(updatedRevision.body.ContainsKey(stringKey), "updatedBody did contained stringKey when not expected");
 
 			// remove the document from the database
-			Task<String> deleteTask = db.Delete(updatedRevision);
+			Task<String> deleteTask = db.DeleteAsync(updatedRevision);
 			deleteTask.Wait();
 			Assert.False(deleteTask.IsFaulted, "delete unexpectedly failed");
 			Assert.NotNull(deleteTask.Result, "delete result not returned as expected.");
@@ -147,7 +147,7 @@ namespace Test.Shared
 		{
 			// Save DocumentRevision without a body
 			DocumentRevision revision = new DocumentRevision();
-			Task<DocumentRevision> saveTask = db.Create(revision);
+			Task<DocumentRevision> saveTask = db.CreateAsync(revision);
 			saveTask.Wait();
 			Assert.True(!saveTask.IsFaulted, "failed to save DocumentRevision with empty body");
 		}
@@ -161,7 +161,7 @@ namespace Test.Shared
 			revision.body = body;
 
 			// Save DocumentRevision with a body
-			Task<DocumentRevision> saveTask = db.Create(revision);
+			Task<DocumentRevision> saveTask = db.CreateAsync(revision);
 			saveTask.Wait();
 			Assert.True(!saveTask.IsFaulted, "failed to save DocumentRevision with body");
 		}
@@ -172,7 +172,7 @@ namespace Test.Shared
 			try
 			{
 				// Save null
-				Task<DocumentRevision> saveTask = db.Create(null);
+				Task<DocumentRevision> saveTask = db.CreateAsync(null);
 				saveTask.Wait();
 				Assert.False(true, "save should raise exception on save of null");
 			}
@@ -188,7 +188,7 @@ namespace Test.Shared
 			try
 			{
 				// fetch null
-				Task<DocumentRevision> fetchByIdTask = db.Read(null);
+				Task<DocumentRevision> fetchByIdTask = db.ReadAsync(null);
 				fetchByIdTask.Wait();
 				Assert.True(fetchByIdTask.IsFaulted, "find should produce fault on fetch of null");
 			}
@@ -204,7 +204,7 @@ namespace Test.Shared
 			try
 			{
 				// fetch empty string
-				Task<DocumentRevision> fetchByIdTask = db.Read("");
+				Task<DocumentRevision> fetchByIdTask = db.ReadAsync("");
 				fetchByIdTask.Wait();
 				Assert.True(fetchByIdTask.IsFaulted, "find should produce fault on find of empty string");
 			}
@@ -220,7 +220,7 @@ namespace Test.Shared
 			// fetch id that doesn't exist
 			Assert.Throws<AggregateException>(() =>
 				{
-					Task<DocumentRevision> fetchByIdTask = db.Read("1234");
+					Task<DocumentRevision> fetchByIdTask = db.ReadAsync("1234");
 					fetchByIdTask.Wait();
 
 				});   
@@ -232,7 +232,7 @@ namespace Test.Shared
 			try
 			{
 				// delete null
-				Task<String> deleteTask = db.Delete(null);
+				Task<String> deleteTask = db.DeleteAsync(null);
 				deleteTask.Wait();
 				Assert.True(deleteTask.IsFaulted, "remove should produce fault on remove of null");
 			}
@@ -250,7 +250,7 @@ namespace Test.Shared
 			{
 				// Save DocumentRevision without a body
 				DocumentRevision revision = new DocumentRevision();
-				Task <String> deleteTask = db.Delete(revision);
+				Task <String> deleteTask = db.DeleteAsync(revision);
 				deleteTask.Wait();
 				Assert.True(deleteTask.IsFaulted, "delete DocumentRevision that does not exist should fail");
 			}
@@ -267,7 +267,7 @@ namespace Test.Shared
 
 			var sortField = new SortField(){ sort = Sort.desc, name = ageKey };
 
-			var task = db.Query(selector: new Dictionary<string,object>()
+			var task = db.QueryAsync(selector: new Dictionary<string,object>()
 				{
                 [ageKey ] = 5
 				}, sort: new List<SortField>()
@@ -297,7 +297,7 @@ namespace Test.Shared
 			sortField.name = ageKey;
 			sortField.sort = Sort.desc;
 
-			var task = db.Query(selector: new Dictionary<string,object>()
+			var task = db.QueryAsync(selector: new Dictionary<string,object>()
 				{
                 [ageKey ] = new Dictionary<string,int>()
 					{
@@ -332,7 +332,7 @@ namespace Test.Shared
 				sort = Sort.desc
 			};
 
-			var task = db.Query(selector: new Dictionary<string,object>()
+			var task = db.QueryAsync(selector: new Dictionary<string,object>()
 				{
                 [ageKey ] = new Dictionary<string,int>()
 					{
@@ -363,7 +363,7 @@ namespace Test.Shared
 			var sortField = new SortField();
 			sortField.name = ageKey;
 
-			var task = db.Query(selector: new Dictionary<string,object>()
+			var task = db.QueryAsync(selector: new Dictionary<string,object>()
 				{
                 [ageKey ] = new Dictionary<string,int>()
 					{
@@ -418,7 +418,7 @@ namespace Test.Shared
 			var db = client.Database("my/database");
 			try
 			{
-				db.EnsureExists().Wait();
+				db.EnsureExistsAsync().Wait();
 
 				var document = new DocumentRevision()
 				{
@@ -442,7 +442,7 @@ namespace Test.Shared
 			}
 			finally
 			{
-				db.Delete().Wait();
+				db.DeleteAsync().Wait();
 			}
 
 		}
@@ -815,7 +815,7 @@ namespace Test.Shared
 
 		private DocumentRevision CreateAndAssert(DocumentRevision document)
 		{
-			Task<DocumentRevision> task = db.Create(document);
+			Task<DocumentRevision> task = db.CreateAsync(document);
 			task.Wait();
 			Assert.IsFalse(task.IsFaulted);
 			Assert.IsNotNull(task.Result);
@@ -829,7 +829,7 @@ namespace Test.Shared
 
 		private void ReadAndAssert(DocumentRevision document, DocumentRevision savedDocument)
 		{
-			var readDocumentTask = db.Read(document.docId);
+			var readDocumentTask = db.ReadAsync(document.docId);
 			readDocumentTask.Wait();
 			Assert.IsFalse(readDocumentTask.IsFaulted);
 			Assert.AreEqual(savedDocument, readDocumentTask.Result);
@@ -838,7 +838,7 @@ namespace Test.Shared
 		private DocumentRevision UpdateAndAssert(DocumentRevision document, DocumentRevision savedDocument)
 		{
 			savedDocument.body.Add("updated", true);
-			var updateTask = db.Update(savedDocument);
+			var updateTask = db.UpdateAsync(savedDocument);
 			updateTask.Wait();
 			Assert.IsFalse(updateTask.IsFaulted);
 			Assert.AreEqual(document.docId, updateTask.Result.docId);
@@ -847,7 +847,7 @@ namespace Test.Shared
 
 		private void DeleteAndAssert(DocumentRevision updated)
 		{
-			var deleteTask = db.Delete(updated);
+			var deleteTask = db.DeleteAsync(updated);
 			deleteTask.Wait();
 			Assert.IsFalse(deleteTask.IsFaulted);
 		}
@@ -856,7 +856,7 @@ namespace Test.Shared
 		private void doQuerySetupWithFields(String indexName, List<SortField> indexFields)
 		{
 
-			var indexTask = db.CreateJsonIndex(fields: indexFields, indexName: indexName);
+			var indexTask = db.CreateJsonIndexAsync(fields: indexFields, indexName: indexName);
 			indexTask.Wait();
 
 			for (int i = 0; i < 20; i++)
@@ -867,7 +867,7 @@ namespace Test.Shared
 
 				DocumentRevision revision = new DocumentRevision();
 				revision.body = dictionary;
-				Task<DocumentRevision> task = db.Create(revision);
+				Task<DocumentRevision> task = db.CreateAsync(revision);
 				task.Wait();
 			}               
 		}

--- a/src/Test.Shared/IndexTests.cs
+++ b/src/Test.Shared/IndexTests.cs
@@ -1,4 +1,4 @@
-﻿//
+//
 //  Copyright (c) 2015 IBM Corp. All rights reserved.
 //
 //  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
@@ -35,14 +35,14 @@ namespace Test.Shared
 			}.GetResult();
 
 			string DBName = "httphelpertests" + DateTime.Now.Ticks;
-			db = client.Database(DBName);
-			db.EnsureExists().Wait();
+            db = client.Database (DBName);
+            db.EnsureExistsAsync ().Wait ();
 		}
 
 		[TearDown]
 		public void tearDown()
 		{
-			db.Delete().Wait();
+            db.DeleteAsync ().Wait ();
 		}
 
 
@@ -58,9 +58,9 @@ namespace Test.Shared
 				sortItem
 			};
 
-			var task = db.CreateJsonIndex(fields: fields, indexName: "myindex", designDocumentName: "myddoc");
-			task.Wait();
-			Assert.IsFalse(task.IsFaulted);
+            var task = db.CreateJsonIndexAsync (fields: fields, indexName: "myindex", designDocumentName: "myddoc");
+            task.Wait ();
+            Assert.IsFalse (task.IsFaulted);
 		}
 
 		[Test] 
@@ -74,9 +74,9 @@ namespace Test.Shared
 				sortItem
 			};
 
-			var task = db.CreateJsonIndex(fields: fields);
-			task.Wait();
-			Assert.IsFalse(task.IsFaulted);
+            var task = db.CreateJsonIndexAsync (fields: fields);
+            task.Wait ();
+            Assert.IsFalse (task.IsFaulted);
 		}
 
 		[Test] 
@@ -90,9 +90,9 @@ namespace Test.Shared
 				sortItem
 			};
 
-			var task = db.CreateJsonIndex(fields: fields, indexName: "myindex");
-			task.Wait();
-			Assert.IsFalse(task.IsFaulted);
+            var task = db.CreateJsonIndexAsync (fields: fields, indexName: "myindex");
+            task.Wait ();
+            Assert.IsFalse (task.IsFaulted);
 		}
 
 		[Test] 
@@ -106,9 +106,9 @@ namespace Test.Shared
 				sortItem
 			};
 
-			var task = db.CreateJsonIndex(fields: fields, designDocumentName: "myddoc");
-			task.Wait();
-			Assert.IsFalse(task.IsFaulted);
+            var task = db.CreateJsonIndexAsync (fields: fields, designDocumentName: "myddoc");
+            task.Wait ();
+            Assert.IsFalse (task.IsFaulted);
 		}
 
 		[Test]
@@ -128,7 +128,7 @@ namespace Test.Shared
               ["foo" ] = "bar"  
 			};
 
-			var task = db.CreateTextIndex(fields: fields,
+            var task = db.CreateTextIndexAsync (fields: fields,
 				           indexName: "myindex",
 				           designDocumentName: "myddoc",
 				           selector: selector,
@@ -141,9 +141,9 @@ namespace Test.Shared
 		[Test]
 		public void createTextIndexOnlyDefaultField()
 		{
-			var task = db.CreateTextIndex(defaultFieldEnabled: true);
-			task.Wait();
-			Assert.IsFalse(task.IsFaulted);
+            var task = db.CreateTextIndexAsync (defaultFieldEnabled: true);
+            task.Wait ();
+            Assert.IsFalse (task.IsFaulted);
 		}
 
 		[Test]
@@ -158,32 +158,31 @@ namespace Test.Shared
 				}
 			};
 
-			var task = db.CreateTextIndex(fields: fields);
-			task.Wait();
-			Assert.IsFalse(task.IsFaulted);
+            var task = db.CreateTextIndexAsync (fields: fields);
+            task.Wait ();
+            Assert.IsFalse (task.IsFaulted);
 		}
 
 		[Test]
 		public void createTextIndexOnlyNameDefaultField()
 		{
-			var task = db.CreateTextIndex(indexName: "defaultFieldIndex", defaultFieldEnabled: true);
-			task.Wait();
-			Assert.IsFalse(task.IsFaulted);
+            var task = db.CreateTextIndexAsync (indexName: "defaultFieldIndex", defaultFieldEnabled: true);
+            task.Wait ();
+            Assert.IsFalse (task.IsFaulted);
 		}
 
 		[Test]
 		public void createTextIndexOnlyDDocNameDefaultField()
 		{
-			var task = db.CreateTextIndex(designDocumentName: "myddoc", defaultFieldEnabled: true);
-			task.Wait();
-			Assert.IsFalse(task.IsFaulted);
+            var task = db.CreateTextIndexAsync (designDocumentName: "myddoc", defaultFieldEnabled: true);
+            task.Wait ();
+            Assert.IsFalse (task.IsFaulted);
 		}
 
 		[Test]
 		public void createTextIndexOnlySelectorDefaultField()
 		{
-			var task = db.CreateTextIndex(defaultFieldEnabled: true, selector: new Dictionary<string,object>()
-				{
+            var task = db.CreateTextIndexAsync (defaultFieldEnabled: true, selector: new Dictionary<string,object> () {
                 ["foo" ] = "bar"  
 				});
 			task.Wait();
@@ -193,9 +192,9 @@ namespace Test.Shared
 		[Test]
 		public void createTexIndexOnlyDefaultFieldAnalyzer()
 		{
-			var task = db.CreateTextIndex(defaultFieldAnalyzer: "english", defaultFieldEnabled: true);
-			task.Wait();
-			Assert.IsFalse(task.IsFaulted);
+            var task = db.CreateTextIndexAsync (defaultFieldAnalyzer: "english", defaultFieldEnabled: true);
+            task.Wait ();
+            Assert.IsFalse (task.IsFaulted);
 		}
             
 

--- a/src/Test.Shared/InterceptorsTests.cs
+++ b/src/Test.Shared/InterceptorsTests.cs
@@ -1,4 +1,4 @@
-﻿//
+//
 //  Copyright (c) 2015 IBM Corp. All rights reserved.
 //
 //  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
@@ -40,8 +40,8 @@ namespace Test.Shared
 		{
 			if (db != null)
 			{
-				Task deleteDBTask = db.Delete();
-				deleteDBTask.Wait();
+                Task deleteDBTask = db.DeleteAsync ();
+                deleteDBTask.Wait ();
 
 				if (deleteDBTask.IsFaulted)
 					Debug.WriteLine("Failed to delete remote DB name: " + DBName + "\nError: " + deleteDBTask.Exception.Message);
@@ -62,9 +62,9 @@ namespace Test.Shared
 
 			Assert.DoesNotThrow(async () =>
 				{
-					await db.EnsureExists().ConfigureAwait(continueOnCapturedContext: false);
-				},
-				"Exception thrown while creating database using BasicAuth interceptor. ");
+                await db.EnsureExistsAsync ().ConfigureAwait (continueOnCapturedContext: false);
+            },
+                "Exception thrown while creating database using BasicAuth interceptor. ");
 
 			Assert.NotNull(db);
 
@@ -84,9 +84,9 @@ namespace Test.Shared
 
 			Assert.DoesNotThrow(async () =>
 				{
-					await db.EnsureExists().ConfigureAwait(continueOnCapturedContext: false);
-				},
-				"Exception thrown while creating database using cookie interceptor. ");
+                await db.EnsureExistsAsync ().ConfigureAwait (continueOnCapturedContext: false);
+            },
+                "Exception thrown while creating database using cookie interceptor. ");
 
 			Assert.NotNull(db);
 		}


### PR DESCRIPTION
## What

Add `Async` to all async methods in the Database class.
## Why

C# convention dictates that Async methods should have the `Async` suffix.
## Reviewers

reviewer @alfinkel 
## Issues

Fixes #25
