### PR TITLE
Fix handling of empty docids and revids

### DIFF
--- a/src/CloudantClient.PCL/src/Database.cs
+++ b/src/CloudantClient.PCL/src/Database.cs
@@ -124,7 +124,7 @@ namespace IBM.Cloudant.Client
             }
                 
             string encodedDocId = null;
-            if (revision.docId != null)
+            if (!string.IsNullOrEmpty(revision.docId))
             {
                 encodedDocId = Uri.EscapeDataString(revision.docId);
             }
@@ -137,7 +137,7 @@ namespace IBM.Cloudant.Client
             // Send the HTTP request
             HttpResponseMessage response;
 
-            if (revision.docId != null)
+            if (!string.IsNullOrEmpty(revision.docId))
             {
                 response = await client.httpHelper.sendPut(uri, null, payload).ConfigureAwait(continueOnCapturedContext: false);
             }
@@ -179,23 +179,20 @@ namespace IBM.Cloudant.Client
 
             }                
 
-            if (revision.revId == null)
+            if (string.IsNullOrEmpty(revision.revId))
             {
                 throw new DataException(DataException.Database_SaveDocumentRevisionFailure,
                     "The document revision must contain a revId to perform an update");
             }
                 
-            Uri uri = null;
 
-            if (revision.docId != null)
-            {
-                uri = new Uri(dbNameUrlEncoded + "/" + Uri.EscapeDataString(revision.docId), UriKind.Relative);
-            }
-            else
+            if (string.IsNullOrEmpty(revision.docId))
             {
                 var errorMessage = "HTTP request to update document failed: the document revision must contain docId";
                 throw new DataException(DataException.Database_SaveDocumentRevisionFailure, errorMessage);
             }
+
+            var uri = new Uri(dbNameUrlEncoded + "/" + Uri.EscapeDataString(revision.docId), UriKind.Relative);
             Debug.WriteLine("relative URI is: " + uri.ToString());
 
             if (revision.body == null)

--- a/src/CloudantClient.PCL/src/DocumentRevisionConverter.cs
+++ b/src/CloudantClient.PCL/src/DocumentRevisionConverter.cs
@@ -74,13 +74,13 @@ namespace IBM.Cloudant.Client
             var document = value as DocumentRevision;
             writer.WriteStartObject();
 
-            if (document.docId != null)
+            if (!string.IsNullOrEmpty(document.docId))
             {
                 writer.WritePropertyName("_id");
                 serializer.Serialize(writer, document.docId);
             }
 
-            if (document.revId != null)
+            if (!string.IsNullOrEmpty(document.revId))
             {
                 writer.WritePropertyName("_rev");
                 serializer.Serialize(writer, document.revId);

--- a/src/Test.Shared/DatabaseCRUDTests.cs
+++ b/src/Test.Shared/DatabaseCRUDTests.cs
@@ -79,6 +79,56 @@ namespace Test.Shared
         }
 
         [Test]
+        public void testCreateWithEmptyDocId()
+        {
+            var document = new DocumentRevision()
+            {
+                docId = "",
+                body = new Dictionary<string,object>()
+                {
+                    ["hello" ] = "world"
+                }
+                    
+            };
+
+            Assert.DoesNotThrow(() => db.CreateAsync(document).Wait());
+        }
+
+        [Test]
+        public void testUpdateWithEmptyDocId()
+        {
+            var document = new DocumentRevision()
+            {
+                docId = "",
+                revId = "1-blhjyurbgufbhfuonUJFB",
+                body = new Dictionary<string,object>()
+                {
+                        ["hello" ] = "world"
+                }
+
+            };
+            Assert.Throws<AggregateException>(() => db.UpdateAsync(document).Wait());
+        }
+
+        [Test]
+        public void testUpdateWithEmptyRevId()
+        {
+            var document = new DocumentRevision()
+            {
+                docId = "helloworld",
+                revId = "",
+                body = new Dictionary<string,object>()
+                {
+                        ["hello" ] = "world"
+                }
+
+            };
+            Assert.Throws<AggregateException>(() => 
+            db.UpdateAsync(document).Wait()
+            );
+        }
+
+        [Test]
         public void testSaveFetchDeleteDocument()
         {
 


### PR DESCRIPTION
## What

Fix issue where a document would fail to be created/updated if the doc id was set to an empty string.
## Reviewers
## Issues

Fixes #36
