### PR TITLE
Throw SerializationException instead of DataException

### DIFF
--- a/src/CloudantClient.PCL/src/SortFieldConverter.cs
+++ b/src/CloudantClient.PCL/src/SortFieldConverter.cs
@@ -14,6 +14,7 @@ using System;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using System.Collections.Generic;
+using System.Runtime.Serialization;
 
 namespace IBM.Cloudant.Client
 {
@@ -50,7 +51,7 @@ namespace IBM.Cloudant.Client
             }
             else
             {
-                throw new DataException(-1, "Unexpected json for Sort Field");
+                throw new SerializationException("Unexpected JSON for Sort Field");
             }
 
               


### PR DESCRIPTION
## What

Throw SerializationException instead of DataException
## Why

SerializationException is a better fit for the error that is being propagated.
## Reviewer

reviewer @ricellis  
## Issue
#27
